### PR TITLE
Revert "Bump net.revelc.code.formatter:formatter-maven-plugin from 2.0.1 to 2.7.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.7.2</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Reverts PhoenicisOrg/phoenicis#1213

Running `mvn clean package` changes the formatting of many files. The config file does not seem to be considered.