### PR TITLE
Use Ruby 2.5 for Travis CI GitHub Pages check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       os: linux
       language: ruby
       rvm:
-        - 2.1
+        - 2.5
       before_install: cd docs
       script:
         - bundle exec jekyll build


### PR DESCRIPTION
Travis output:
```
Gem::RuntimeRequirementNotMetError: github-pages-health-check requires Ruby version >= 2.2.0. The current ruby version is 2.1.0.
Gem::RuntimeRequirementNotMetError: ruby_dep requires Ruby version >= 2.2.5, ~> 2.2. The current ruby version is 2.1.0.
```