### PR TITLE
Change verb and application implementations to return JSON objects

### DIFF
--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/EngineToolsManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/EngineToolsManager.java
@@ -39,6 +39,7 @@ public class EngineToolsManager {
 
     /**
      * constructor
+     *
      * @param scriptInterpreter
      */
     public EngineToolsManager(ScriptInterpreter scriptInterpreter) {
@@ -47,27 +48,30 @@ public class EngineToolsManager {
 
     /**
      * runs a tool in a given container
-     * @param engineId ID of the engine which provides the tool (e.g. "Wine")
-     * @param container name of the container
-     * @param toolId ID of the tool
-     * @param doneCallback callback executed after the script ran
+     *
+     * @param engineId      ID of the engine which provides the tool (e.g. "Wine")
+     * @param container     name of the container
+     * @param toolId        ID of the tool
+     * @param doneCallback  callback executed after the script ran
      * @param errorCallback callback executed in case of an error
      */
     public void runTool(String engineId, String container, String toolId, Runnable doneCallback,
             Consumer<Exception> errorCallback) {
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        interactiveScriptSession.eval(
-                "include([\"engines\", \"" + engineId + "\", \"tools\", \"" + toolId + "\"]);",
-                ignored -> interactiveScriptSession.eval("new Tool()", output -> {
-                    final EngineTool toolObject = (EngineTool) output;
+        String script = "include([\"engines\", \"" + engineId + "\", \"tools\", \"" + toolId + "\"]);";
+
+        interactiveScriptSession.eval(script, EngineTool.class,
+                toolObject -> {
                     toolObject.run(container);
                     doneCallback.run();
-                }, errorCallback), errorCallback);
+                },
+                errorCallback);
     }
 
     /**
      * fetches the available engine tools
+     *
      * @param repositoryDTO
      * @param callback
      */

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -87,9 +87,8 @@ public class AppsController {
                     executeBuilder.append(scriptDTO.getId());
                     executeBuilder.append("\";\n");
                     executeBuilder.append(scriptDTO.getScript());
-                    executeBuilder.append("\n");
+
                     // TODO: use Java interface instead of String
-                    executeBuilder.append("new Installer().run();");
                     scriptInterpreter.runScript(executeBuilder.toString(), e -> Platform.runLater(() -> {
                         // no exception if installation is cancelled
                         if (!(e.getCause() instanceof InterruptedException)) {

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/BackgroundScriptInterpreter.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/BackgroundScriptInterpreter.java
@@ -39,8 +39,19 @@ public class BackgroundScriptInterpreter implements ScriptInterpreter {
     public InteractiveScriptSession createInteractiveSession() {
         final InteractiveScriptSession interactiveScriptSession = delegated.createInteractiveSession();
 
-        return (evaluation, responseCallback, errorCallback) -> {
-            executorService.execute(() -> interactiveScriptSession.eval(evaluation, responseCallback, errorCallback));
+        return new InteractiveScriptSession() {
+            @Override
+            public void eval(String evaluation, Consumer<Object> responseCallback, Consumer<Exception> errorCallback) {
+                executorService
+                        .execute(() -> interactiveScriptSession.eval(evaluation, responseCallback, errorCallback));
+            }
+
+            @Override
+            public <T> void eval(String evaluation, Class<T> responseType, Consumer<T> responseCallback,
+                    Consumer<Exception> errorCallback) {
+                executorService.execute(
+                        () -> interactiveScriptSession.eval(evaluation, responseType, responseCallback, errorCallback));
+            }
         };
     }
 }

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/InteractiveScriptSession.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/InteractiveScriptSession.java
@@ -22,4 +22,20 @@ import java.util.function.Consumer;
 
 public interface InteractiveScriptSession {
     void eval(String evaluation, Consumer<Object> responseCallback, Consumer<Exception> errorCallback);
+
+    /**
+     * Evaluates the given script {@link String evaluation}.
+     * The resulting json object of the script evaluation is used to create a new Java object of type {@link T}, which is
+     * passed to the {@link Consumer<T> responseCallback} function.
+     * <p>
+     * If an error occurs during this process, the corresponding exception gets passed to the {@link Consumer<Exception> errorCallback} function.
+     *
+     * @param evaluation       The script to be evaluated. This script needs to return a json object
+     * @param responseType     The return class of the script
+     * @param responseCallback The response callback method
+     * @param errorCallback    The error callback method
+     * @param <T>              The return type of the script
+     */
+    <T> void eval(String evaluation, Class<T> responseType, Consumer<T> responseCallback,
+            Consumer<Exception> errorCallback);
 }

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/nashorn/NashornScriptInterpreter.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/nashorn/NashornScriptInterpreter.java
@@ -18,6 +18,7 @@
 
 package org.phoenicis.scripts.nashorn;
 
+import org.phoenicis.scripts.Installer;
 import org.phoenicis.scripts.interpreter.InteractiveScriptSession;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 
@@ -32,7 +33,14 @@ public class NashornScriptInterpreter implements ScriptInterpreter {
 
     @Override
     public void runScript(String scriptContent, Runnable doneCallback, Consumer<Exception> errorCallback) {
-        nashornEngineFactory.createEngine().eval(scriptContent, doneCallback, errorCallback);
+        InteractiveScriptSession scriptSession = createInteractiveSession();
+
+        scriptSession.eval(scriptContent, Installer.class,
+                installer -> {
+                    installer.run();
+                    doneCallback.run();
+                },
+                errorCallback);
     }
 
     @Override


### PR DESCRIPTION
This PR targets the changes to the application and verb scripts on the Java application side, as described in #1236.

As a short note:
This PR should only be merged after a corresponding PR for the script changes has been made.

In addition I've asked myself if the CLI client works currently, because the passed parameters to the scripts are kind of different in the two application (i.e. JavaFX vs. CLI).
In the JavaFX application we pass the four ids: `TYPE_ID`, `CATEGORY_ID`, `APPLICATION_ID` and `SCRIPT_ID`.
For the CLI application I couldn't find code that sets these ids, before executing an application script.

Maybe we should try to make both method implementations more uniform.