### PR TITLE
Fix build if Maven project is not a git repository

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
@@ -43,13 +43,13 @@ public class ViewsConfiguration {
     @Value("${application.name}")
     private String applicationName;
 
-    @Value("${application.version}")
+    @Value("${application.version}:unknown")
     private String applicationVersion;
 
-    @Value("${application.gitRevision}")
+    @Value("${application.gitRevision}:unknown")
     private String applicationGitRevision;
 
-    @Value("${application.buildTimestamp}")
+    @Value("${application.buildTimestamp}:unknown")
     private String applicationBuildTimestamp;
 
     @Value("${application.user.engines}")

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <revisionOnScmFailure>unknown</revisionOnScmFailure>
                     <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                     <doCheck>false</doCheck>
                     <doUpdate>false</doUpdate>


### PR DESCRIPTION
Currently, it is not possible to build if the Phoenicis Maven project is not a git repository (e.g. if you just downloaded the .zip from GitHub) because the `buildNumber` variable is not set by buildnumber-maven-plugin.

fixes #1340