### PR TITLE
Build self-contained .jar for JavaFX application

### DIFF
--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -151,13 +151,14 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>native</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
                     <vendor>PhoenicisOrg</vendor>
                     <mainClass>org.phoenicis.javafx.JavaFXApplication</mainClass>
+                    <bundler>linux.app</bundler>
                 </configuration>
             </plugin>
         </plugins>

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -108,6 +108,15 @@
             <version>1.1.10</version>
         </dependency>
     </dependencies>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>oss-sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <build>
         <plugins>
             <plugin>
@@ -146,12 +155,12 @@
             <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
-                <version>8.8.3</version>
+                <version>8.9.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>native</goal>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -143,6 +143,23 @@
                     <mainClass>org.phoenicis.javafx.JavaFXApplication</mainClass>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>8.8.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <vendor>PhoenicisOrg</vendor>
+                    <mainClass>org.phoenicis.javafx.JavaFXApplication</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <!--


### PR DESCRIPTION
Uses [javafx-maven-plugin](https://github.com/javafx-maven-plugin/javafx-maven-plugin) to build a .jar in `phoenicis-javafx/target/jfx/app`. This can be started simply with `java -jar`.

Might also be useful for snap/flatpak.