### PR TITLE
Revert "Revert "Implement workaround for surefire bug 1588""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - docker exec -t ubuntu-18-04 bash -c "cd /travis;
                                                git clone https://github.com/PhoenicisOrg/phoenicis.git;
                                                cd phoenicis;
-                                               mvn -B clean package"
+                                               _JAVA_OPTIONS=-Djdk.net.URLClassPath.disableClassPathURLCheck=true mvn -B clean package"
       before_cache:
         - docker exec -t ubuntu-18-04 bash -c "cp /travis/phoenicis/phoenicis-dist/target/*.deb /travis/travis_cache/"
     # build + test

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                    <configuration>
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Reverts PhoenicisOrg/phoenicis#1464

The pull request build was passing but on master the issue occurred again. I don't know why this is the case but probably we should just live with the workaround for now.