### PR TITLE
Lock git folder during clone/update

### DIFF
--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/types/GitRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/types/GitRepository.java
@@ -66,7 +66,7 @@ public class GitRepository implements Repository {
     }
 
     @Override
-    public synchronized RepositoryDTO fetchInstallableApplications() {
+    public RepositoryDTO fetchInstallableApplications() {
         RepositoryDTO result = null;
         try {
             mutex.acquire();


### PR DESCRIPTION
NOTE: The lock is acquired only for the complete JVM, so it's not a replacement for the `synchronized` block.

fixes #1463