### PR TITLE
Flatpak: use user home

### DIFF
--- a/phoenicis-dist/src/flatpak/org.phoenicis.javafx.json
+++ b/phoenicis-dist/src/flatpak/org.phoenicis.javafx.json
@@ -31,6 +31,7 @@
   },
   "command": "phoenicis-javafx",
   "finish-args": [
+    "--filesystem=home",
     "--allow=multiarch",
     "--share=ipc",
     "--socket=x11",
@@ -80,7 +81,7 @@
           "type": "script",
           "dest-filename": "phoenicis-javafx",
           "commands": [
-            "/app/jre/bin/java -Duser.home=\"$XDG_DATA_HOME\" --module-path /app/phoenicis/lib/ -m org.phoenicis.javafx/org.phoenicis.javafx.JavaFXApplication \"$@\""
+            "/app/jre/bin/java --module-path /app/phoenicis/lib/ -m org.phoenicis.javafx/org.phoenicis.javafx.JavaFXApplication \"$@\""
           ]
         },
         {


### PR DESCRIPTION
Previously, the `.Phoenicis` folder was located in the flatpak runtime environment. Now it uses the "normal" one in the user home. Thus you can share apps, settings etc. regardless if you run the flatpak or deb etc. Moreover, it is persistent if the flatpak is updated/uninstalled.