### PR TITLE
Fix: cannot access TerminalOpener from Javascript with Java 10+

### DIFF
--- a/phoenicis-tools/src/main/java/module-info.java
+++ b/phoenicis-tools/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.phoenicis.tools {
     opens org.phoenicis.tools.gpg;
     opens org.phoenicis.tools.http;
     opens org.phoenicis.tools.system;
+    opens org.phoenicis.tools.system.terminal;
     opens org.phoenicis.tools.version;
     opens org.phoenicis.tools.win32;
     requires bcpg.jdk16;


### PR DESCRIPTION
fixes #1527