### PR TITLE
Fix details view size

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -105,7 +105,7 @@ public class ContainersController {
                         });
                     });
 
-            panel.setOnOpenFileBrower(container -> {
+            panel.setOnOpenFileBrowser(container -> {
                 try {
                     File containerDir = new File(container.getPath());
                     EventQueue.invokeLater(() -> {
@@ -126,6 +126,7 @@ public class ContainersController {
             });
 
             panel.setOnClose(containersView::closeDetailsView);
+            panel.prefWidthProperty().bind(this.containersView.getTabPane().widthProperty().divide(3));
 
             Platform.runLater(() -> containersView.showDetailsView(panel));
             // });

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
@@ -176,7 +176,6 @@ public class ApplicationsView extends MainWindowView<ApplicationsSidebar> {
                 javaFxSettingsManager);
         applicationPanel.setOnScriptInstall(this::installScript);
         applicationPanel.setOnClose(this::closeDetailsView);
-        applicationPanel.setMaxWidth(400);
         applicationPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
         this.showDetailsView(applicationPanel);
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerEngineToolsTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerEngineToolsTab.java
@@ -3,6 +3,7 @@ package org.phoenicis.javafx.views.mainwindow.containers;
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.layout.TilePane;
 import javafx.scene.layout.VBox;
@@ -71,7 +72,15 @@ public class ContainerEngineToolsTab extends Tab {
 
         toolsPane.getChildren().add(toolsContentPane);
 
-        this.setContent(toolsPane);
+        final ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER); // the TilePane adjusts the number of columns
+                                                                    // already
+        toolsContentPane.prefWidthProperty().bind(scrollPane.widthProperty());
+        toolsContentPane.prefHeightProperty().bind(scrollPane.heightProperty());
+        scrollPane.setBackground(toolsContentPane.getBackground());
+        scrollPane.setContent(toolsPane);
+
+        this.setContent(scrollPane);
     }
 
     public void unlockAll() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanel.java
@@ -63,7 +63,7 @@ public class ContainerPanel extends DetailsView {
         this.informationTab.setOnDeletePrefix(onDeletePrefix);
     }
 
-    public void setOnOpenFileBrower(Consumer<ContainerDTO> onOpenFileBrowser) {
+    public void setOnOpenFileBrowser(Consumer<ContainerDTO> onOpenFileBrowser) {
         this.informationTab.setOnOpenFileBrowser(onOpenFileBrowser);
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EnginesView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EnginesView.java
@@ -24,7 +24,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
 import javafx.scene.control.TabPane;
-import java.util.Map;
 import org.phoenicis.engines.Engine;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
 import org.phoenicis.engines.dto.EngineDTO;
@@ -40,6 +39,7 @@ import org.phoenicis.javafx.views.mainwindow.ui.MainWindowView;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -201,10 +201,11 @@ public class EnginesView extends MainWindowView<EnginesSidebar> {
      * @param engineDTO
      */
     private void showEngineDetails(EngineDTO engineDTO, Engine engine) {
-        currentEnginePanel = new EnginePanel(engineDTO, engine);
-        currentEnginePanel.setOnClose(this::closeDetailsView);
-        currentEnginePanel.setOnEngineInstall(this::installEngine);
-        currentEnginePanel.setOnEngineDelete(this::deleteEngine);
+        this.currentEnginePanel = new EnginePanel(engineDTO, engine);
+        this.currentEnginePanel.setOnClose(this::closeDetailsView);
+        this.currentEnginePanel.setOnEngineInstall(this::installEngine);
+        this.currentEnginePanel.setOnEngineDelete(this::deleteEngine);
+        this.currentEnginePanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
 
         this.showDetailsView(currentEnginePanel);
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/InstallationsView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/InstallationsView.java
@@ -144,7 +144,7 @@ public class InstallationsView extends MainWindowView<InstallationsSidebar> {
     private void showInstallationDetails(InstallationDTO installationDTO) {
         this.installationsPanel.setOnClose(this::closeDetailsView);
         this.installationsPanel.setInstallationDTO(installationDTO);
-        this.installationsPanel.setMaxWidth(600);
+        this.installationsPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(2.5));
         this.showDetailsView(this.installationsPanel);
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/InstallationsView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/installations/InstallationsView.java
@@ -144,7 +144,7 @@ public class InstallationsView extends MainWindowView<InstallationsSidebar> {
     private void showInstallationDetails(InstallationDTO installationDTO) {
         this.installationsPanel.setOnClose(this::closeDetailsView);
         this.installationsPanel.setInstallationDTO(installationDTO);
-        this.installationsPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(2.5));
+        this.installationsPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(2));
         this.showDetailsView(this.installationsPanel);
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
@@ -187,7 +187,6 @@ public class LibraryView extends MainWindowView<LibrarySidebar> {
     private void showShortcutDetails(ShortcutDTO shortcutDTO) {
         this.libraryPanel.setOnClose(this::closeDetailsView);
         this.libraryPanel.setShortcutDTO(shortcutDTO);
-        this.libraryPanel.setMaxWidth(400);
         this.libraryPanel.prefWidthProperty().bind(this.getTabPane().widthProperty().divide(3));
         this.showDetailsView(libraryPanel);
     }


### PR DESCRIPTION
Resizes the details view based on the window size. Therefore, the details view is still usable even with a very small window.
![apps](https://user-images.githubusercontent.com/3973260/49536427-c0ffc200-f8c6-11e8-8fdb-1bde5cde37ab.png)

![containers](https://user-images.githubusercontent.com/3973260/49537273-d83faf00-f8c8-11e8-8a22-28a2c0a94c64.png)

![installations](https://user-images.githubusercontent.com/3973260/49538494-d9261000-f8cb-11e8-9d3a-b289c36fb204.png)


fixes #1541
fixes #1410