### PR TITLE
Fix fetching process of the engines before the engines tab is populated

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -56,7 +56,7 @@ public class EnginesController {
     private Map<String, List<EngineSubCategoryDTO>> versionsCache = new HashMap<>();
 
     public EnginesController(EnginesView enginesView, RepositoryManager repositoryManager,
-                             EnginesManager enginesManager, ThemeManager themeManager) {
+            EnginesManager enginesManager, ThemeManager themeManager) {
         super();
 
         this.enginesView = enginesView;
@@ -165,12 +165,12 @@ public class EnginesController {
      * Fetches all engine subcategories that belong to a given list of engine categories
      *
      * @param engineCategories The engine categories
-     * @param result           The temporary transport variable
-     * @param callback         A callback method, which is called after all engine subcategories have been fetched
+     * @param result The temporary transport variable
+     * @param callback A callback method, which is called after all engine subcategories have been fetched
      */
     private void fetchEngineSubcategories(Queue<EngineCategoryDTO> engineCategories,
-                                          Map<EngineCategoryDTO, List<EngineSubCategoryDTO>> result,
-                                          Consumer<Map<EngineCategoryDTO, List<EngineSubCategoryDTO>>> callback) {
+            Map<EngineCategoryDTO, List<EngineSubCategoryDTO>> result,
+            Consumer<Map<EngineCategoryDTO, List<EngineSubCategoryDTO>>> callback) {
         final Queue<EngineCategoryDTO> queue = new ArrayDeque<>(engineCategories);
 
         if (queue.isEmpty()) {
@@ -185,7 +185,7 @@ public class EnginesController {
                     versions -> {
                         // recursively process the remaining engine categories
                         fetchEngineSubcategories(queue,
-                                ImmutableMap.<EngineCategoryDTO, List<EngineSubCategoryDTO>>builder()
+                                ImmutableMap.<EngineCategoryDTO, List<EngineSubCategoryDTO>> builder()
                                         .putAll(result)
                                         .put(engineCategory, versions)
                                         .build(),

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -18,9 +18,11 @@
 
 package org.phoenicis.javafx.controller.engines;
 
+import com.google.common.collect.ImmutableMap;
 import javafx.application.Platform;
 import org.phoenicis.engines.Engine;
 import org.phoenicis.engines.EnginesManager;
+import org.phoenicis.engines.dto.EngineCategoryDTO;
 import org.phoenicis.engines.dto.EngineSubCategoryDTO;
 import org.phoenicis.javafx.controller.apps.AppsController;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
@@ -30,7 +32,6 @@ import org.phoenicis.javafx.views.mainwindow.engines.EnginesView;
 import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.repository.dto.RepositoryDTO;
-import org.phoenicis.repository.dto.TypeDTO;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -39,78 +40,85 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 public class EnginesController {
     private final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(AppsController.class);
     private final EnginesView enginesView;
-    private final RepositoryManager repositoryManager;
     private final EnginesManager enginesManager;
+
     private ThemeManager themeManager;
-    private RepositoryDTO repositoryCache = null;
+    private RepositoryDTO repositoryCache;
     private Map<String, Engine> enginesCache = new HashMap<>();
     private Map<String, List<EngineSubCategoryDTO>> versionsCache = new HashMap<>();
 
     public EnginesController(EnginesView enginesView, RepositoryManager repositoryManager,
-            EnginesManager enginesManager,
-            ThemeManager themeManager) {
+                             EnginesManager enginesManager, ThemeManager themeManager) {
+        super();
+
         this.enginesView = enginesView;
-        this.repositoryManager = repositoryManager;
         this.enginesManager = enginesManager;
         this.themeManager = themeManager;
 
-        this.repositoryManager.addCallbacks(repositoryDTO -> this.enginesManager.fetchAvailableEngines(repositoryDTO,
-                engines -> this.populateView(repositoryDTO, engines),
-                e -> Platform.runLater(() -> enginesView.showFailure(tr("Loading engines failed."), Optional.of(e)))),
+        repositoryManager.addCallbacks(
+                repositoryDTO -> {
+                    enginesManager.fetchAvailableEngines(
+                            repositoryDTO,
+                            engines -> populateView(repositoryDTO, engines),
+                            e -> Platform.runLater(
+                                    () -> enginesView.showFailure(tr("Loading engines failed."), Optional.of(e))));
+                },
                 e -> Platform.runLater(() -> enginesView.showFailure(tr("Loading engines failed."), Optional.of(e))));
 
-        this.enginesView.setOnSelectEngineCategory(engineCategoryDTO -> {
+        enginesView.setOnSelectEngineCategory(engineCategoryDTO -> {
             // TODO: better way to get engine ID
             final String engineId = engineCategoryDTO.getName().toLowerCase();
             // only if not chached
-            if (!this.versionsCache.containsKey(engineId)) {
-                this.enginesManager.fetchAvailableVersions(engineId,
+            if (!versionsCache.containsKey(engineId)) {
+                enginesManager.fetchAvailableVersions(engineId,
                         versions -> {
-                            this.versionsCache.put(engineId, versions);
-                            this.enginesView.updateVersions(engineCategoryDTO, versions);
+                            versionsCache.put(engineId, versions);
+                            enginesView.updateVersions(engineCategoryDTO, versions);
                         },
-                        e -> Platform.runLater(() -> new ErrorMessage("Error", e, this.enginesView).show()));
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e, enginesView).show()));
             }
         });
 
-        this.enginesView.setOnInstallEngine(engineDTO -> {
+        enginesView.setOnInstallEngine(engineDTO -> {
             ConfirmMessage confirmMessage = new ConfirmMessage(
                     tr("Install {0}", engineDTO.getVersion()),
                     tr("Are you sure you want to install {0}?", engineDTO.getVersion()),
-                    this.enginesView.getContent().getScene().getWindow());
+                    enginesView.getContent().getScene().getWindow());
             confirmMessage.setResizable(true);
-            confirmMessage.ask(() -> this.enginesManager.getEngine(engineDTO.getId(),
+            confirmMessage.ask(() -> enginesManager.getEngine(engineDTO.getId(),
                     engine -> {
                         engine.install(engineDTO.getSubCategory(), engineDTO.getVersion());
                         // invalidate cache and force view update to show installed version correctly
-                        this.versionsCache.remove(engineDTO.getId());
-                        this.forceViewUpdate();
+                        versionsCache.remove(engineDTO.getId());
+                        forceViewUpdate();
                     },
                     e -> Platform.runLater(
-                            () -> new ErrorMessage("Error", e, this.enginesView).show())));
+                            () -> new ErrorMessage("Error", e, enginesView).show())));
         });
 
-        this.enginesView.setOnDeleteEngine(engineDTO -> {
+        enginesView.setOnDeleteEngine(engineDTO -> {
             ConfirmMessage confirmMessage = new ConfirmMessage(
                     tr("Delete {0}", engineDTO.getVersion()),
                     tr("Are you sure you want to delete {0}?", engineDTO.getVersion()),
-                    this.enginesView.getContent().getScene().getWindow());
+                    enginesView.getContent().getScene().getWindow());
             confirmMessage.setResizable(true);
-            confirmMessage.ask(() -> this.enginesManager.getEngine(engineDTO.getId(),
+            confirmMessage.ask(() -> enginesManager.getEngine(engineDTO.getId(),
                     engine -> {
                         engine.delete(engineDTO.getSubCategory(), engineDTO.getVersion());
                         // invalidate cache and force view update to show deleted version correctly
-                        this.versionsCache.remove(engineDTO.getId());
-                        this.forceViewUpdate();
+                        versionsCache.remove(engineDTO.getId());
+                        forceViewUpdate();
                     },
                     e -> Platform.runLater(
-                            () -> new ErrorMessage("Error", e, this.enginesView).show())));
+                            () -> new ErrorMessage("Error", e, enginesView).show())));
         });
     }
 
@@ -121,26 +129,84 @@ public class EnginesController {
     private void populateView(RepositoryDTO repositoryDTO, Map<String, Engine> engines) {
         this.repositoryCache = repositoryDTO;
         this.enginesCache = engines;
-        Platform.runLater(() -> {
-            this.enginesView.showWait();
-            List<CategoryDTO> categoryDTOS = new ArrayList<>();
-            for (TypeDTO typeDTO : repositoryDTO.getTypes()) {
-                if (typeDTO.getId().equals("engines")) {
-                    categoryDTOS = typeDTO.getCategories();
-                }
-            }
-            setDefaultEngineIcons(categoryDTOS);
-            this.enginesView.populate(this.enginesManager.getAvailableEngines(categoryDTOS), engines);
+
+        // show a waiting screen until the engines are loaded
+        enginesView.showWait();
+
+        // fetch all categories consisting of engines that are contained in the repository
+        final List<CategoryDTO> categoryDTOS = repositoryDTO.getTypes().stream()
+                .filter(type -> type.getId().equals("engines"))
+                .flatMap(type -> type.getCategories().stream())
+                .collect(Collectors.toList());
+
+        // generate the necessary css for the engine categories
+        setDefaultEngineIcons(categoryDTOS);
+
+        // fetch the engine categories objects contained in the engine categories
+        final Queue<EngineCategoryDTO> engineCategories = new ArrayDeque<>(
+                enginesManager.getAvailableEngines(categoryDTOS));
+
+        // insert the missing engine subcategories into the engine categories
+        fetchEngineSubcategories(engineCategories, ImmutableMap.of(), subcategoryMap -> {
+            final List<EngineCategoryDTO> categories = subcategoryMap.entrySet().stream()
+                    .map(entry -> new EngineCategoryDTO.Builder(entry.getKey())
+                            .withSubCategories(entry.getValue())
+                            .build())
+                    .collect(Collectors.toList());
+
+            Platform.runLater(() -> {
+                // update the view
+                enginesView.populate(categories, engines);
+            });
         });
     }
 
     /**
-     * forces an update of the view
+     * Fetches all engine subcategories that belong to a given list of engine categories
+     *
+     * @param engineCategories The engine categories
+     * @param result           The temporary transport variable
+     * @param callback         A callback method, which is called after all engine subcategories have been fetched
      */
-    private void forceViewUpdate() {
-        this.populateView(this.repositoryCache, this.enginesCache);
+    private void fetchEngineSubcategories(Queue<EngineCategoryDTO> engineCategories,
+                                          Map<EngineCategoryDTO, List<EngineSubCategoryDTO>> result,
+                                          Consumer<Map<EngineCategoryDTO, List<EngineSubCategoryDTO>>> callback) {
+        final Queue<EngineCategoryDTO> queue = new ArrayDeque<>(engineCategories);
+
+        if (queue.isEmpty()) {
+            // recursion anchor
+            callback.accept(result);
+        } else {
+            final EngineCategoryDTO engineCategory = queue.poll();
+            final String engineId = engineCategory.getName().toLowerCase();
+
+            enginesManager.fetchAvailableVersions(
+                    engineId,
+                    versions -> {
+                        // recursively process the remaining engine categories
+                        fetchEngineSubcategories(queue,
+                                ImmutableMap.<EngineCategoryDTO, List<EngineSubCategoryDTO>>builder()
+                                        .putAll(result)
+                                        .put(engineCategory, versions)
+                                        .build(),
+                                callback);
+                    },
+                    e -> Platform.runLater(() -> new ErrorMessage("Error", e, enginesView).show()));
+        }
     }
 
+    /**
+     * Forces an update of the view
+     */
+    private void forceViewUpdate() {
+        populateView(repositoryCache, enginesCache);
+    }
+
+    /**
+     * Generates css for the button design associated with the given categories
+     *
+     * @param categoryDTOS The categories
+     */
     private void setDefaultEngineIcons(List<CategoryDTO> categoryDTOS) {
         try {
             StringBuilder cssBuilder = new StringBuilder();
@@ -161,6 +227,7 @@ public class EnginesController {
             tempFile.deleteOnExit();
             Files.write(temp, css.getBytes());
             String defaultEngineIconsCss = temp.toUri().toString();
+
             themeManager.setDefaultEngineIconsCss(defaultEngineIconsCss);
         } catch (IOException e) {
             LOGGER.warn("Could not set default engine icons.", e);


### PR DESCRIPTION
Currently the loading process of the engines for the engines tab is strange.
The engine categories are loaded without their subcategories.
This in turn should prevent them from showing up in the sidebar of the engines tab, because they are then assumed to be empty.

This PR solves this problem by additionally fetching all subcategories of the fetched engine categories, before the engines tab is populated.

This PR is part of #1536 