### PR TITLE
Fix list widget selection bug

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/compact/skin/CompactListWidgetSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/compact/skin/CompactListWidgetSkin.java
@@ -5,11 +5,13 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import org.phoenicis.javafx.collections.MappedList;
+import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.common.widgets.compact.control.CompactListElement;
 import org.phoenicis.javafx.components.common.widgets.compact.control.CompactListWidget;
-import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetElement;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetSelection;
+
+import java.util.Optional;
 
 /**
  * The skin for the {@link CompactListWidget} component
@@ -70,25 +72,50 @@ public class CompactListWidgetSkin<E> extends SkinBase<CompactListWidget<E>, Com
             return listCell;
         });
 
+        Bindings.bindContent(container.getItems(), mappedElements);
+
         // ensure that updates to the selected element property are automatically reflected in the view
         getControl().selectedElementProperty().addListener((observable, oldValue, newValue) -> {
             // deselect the old element
-            if (oldValue != null) {
-                final int oldValueIndex = getControl().getElements().indexOf(oldValue.getSelection());
-
-                container.getSelectionModel().clearSelection(oldValueIndex);
-            }
+            updateOldSelection(container, oldValue);
 
             // select the new element
-            if (newValue != null) {
-                final int newValueIndex = getControl().getElements().indexOf(newValue.getSelection());
-
-                container.getSelectionModel().select(newValueIndex);
-            }
+            updateNewSelection(container, newValue);
         });
 
-        Bindings.bindContent(container.getItems(), mappedElements);
+        // initialise selection at startup
+        updateNewSelection(container, getControl().getSelectedElement());
 
         getChildren().addAll(container);
+    }
+
+    /**
+     * Deselect the old/previous selection
+     *
+     * @param container The list view in which the selection should be updated
+     * @param oldSelection The old/previous selection
+     */
+    private void updateOldSelection(ListView<CompactListElement<E>> container, ListWidgetSelection<E> oldSelection) {
+        // deselect the old element
+        Optional.ofNullable(oldSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int oldValueIndex = getControl().getElements().indexOf(selection);
+
+            container.getSelectionModel().clearSelection(oldValueIndex);
+        });
+    }
+
+    /**
+     * Select the current/new selection
+     *
+     * @param container The list view in which the selection should be updated
+     * @param newSelection The current/new selection
+     */
+    private void updateNewSelection(ListView<CompactListElement<E>> container, ListWidgetSelection<E> newSelection) {
+        // select the new element
+        Optional.ofNullable(newSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int newValueIndex = getControl().getElements().indexOf(selection);
+
+            container.getSelectionModel().select(newValueIndex);
+        });
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/details/skin/DetailsListWidgetSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/details/skin/DetailsListWidgetSkin.java
@@ -11,6 +11,8 @@ import org.phoenicis.javafx.components.common.widgets.details.control.DetailsLis
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetElement;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetSelection;
 
+import java.util.Optional;
+
 /**
  * The skin for the {@link DetailsListWidget} component
  *
@@ -70,25 +72,50 @@ public class DetailsListWidgetSkin<E> extends SkinBase<DetailsListWidget<E>, Det
             return listCell;
         });
 
+        Bindings.bindContent(container.getItems(), mappedElements);
+
         // ensure that updates to the selected element property are automatically reflected in the view
         getControl().selectedElementProperty().addListener((observable, oldValue, newValue) -> {
             // deselect the old element
-            if (oldValue != null) {
-                final int oldValueIndex = getControl().getElements().indexOf(oldValue.getSelection());
-
-                container.getSelectionModel().clearSelection(oldValueIndex);
-            }
+            updateOldSelection(container, oldValue);
 
             // select the new element
-            if (newValue != null) {
-                final int newValueIndex = getControl().getElements().indexOf(newValue.getSelection());
-
-                container.getSelectionModel().select(newValueIndex);
-            }
+            updateNewSelection(container, newValue);
         });
 
-        Bindings.bindContent(container.getItems(), mappedElements);
+        // initialise selection at startup
+        updateNewSelection(container, getControl().getSelectedElement());
 
         getChildren().addAll(container);
+    }
+
+    /**
+     * Deselect the old/previous selection
+     *
+     * @param container The list view in which the selection should be updated
+     * @param oldSelection The old/previous selection
+     */
+    private void updateOldSelection(ListView<DetailsListElement<E>> container, ListWidgetSelection<E> oldSelection) {
+        // deselect the old element
+        Optional.ofNullable(oldSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int oldValueIndex = getControl().getElements().indexOf(selection);
+
+            container.getSelectionModel().clearSelection(oldValueIndex);
+        });
+    }
+
+    /**
+     * Select the current/new selection
+     *
+     * @param container The list view in which the selection should be updated
+     * @param newSelection The current/new selection
+     */
+    private void updateNewSelection(ListView<DetailsListElement<E>> container, ListWidgetSelection<E> newSelection) {
+        // select the new element
+        Optional.ofNullable(newSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int newValueIndex = getControl().getElements().indexOf(selection);
+
+            container.getSelectionModel().select(newValueIndex);
+        });
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/icons/skin/IconsListWidgetSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/widgets/icons/skin/IconsListWidgetSkin.java
@@ -6,11 +6,13 @@ import javafx.scene.CacheHint;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
 import org.phoenicis.javafx.collections.MappedList;
+import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.common.widgets.icons.control.IconsListElement;
 import org.phoenicis.javafx.components.common.widgets.icons.control.IconsListWidget;
-import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetElement;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetSelection;
+
+import java.util.Optional;
 
 /**
  * The skin for the {@link IconsListWidget} component
@@ -69,29 +71,52 @@ public class IconsListWidgetSkin<E> extends SkinBase<IconsListWidget<E>, IconsLi
         content.prefWidthProperty().bind(container.widthProperty());
         content.setPrefHeight(0);
 
+        Bindings.bindContent(content.getChildren(), mappedElements);
+
         // ensure that updates to the selected element property are automatically reflected in the view
         getControl().selectedElementProperty().addListener((observable, oldValue, newValue) -> {
             // deselect the old element
-            if (oldValue != null) {
-                final int oldValueIndex = getControl().getElements().indexOf(oldValue.getSelection());
-
-                IconsListElement<E> oldElement = mappedElements.get(oldValueIndex);
-
-                oldElement.setSelected(false);
-            }
+            updateOldSelection(oldValue);
 
             // select the new element
-            if (newValue != null) {
-                final int newValueIndex = getControl().getElements().indexOf(newValue.getSelection());
-
-                IconsListElement<E> newElement = mappedElements.get(newValueIndex);
-
-                newElement.setSelected(true);
-            }
+            updateNewSelection(newValue);
         });
 
-        Bindings.bindContent(content.getChildren(), mappedElements);
+        // initialise selection at startup
+        updateNewSelection(getControl().getSelectedElement());
 
         return content;
+    }
+
+    /**
+     * Deselect the old/previous selection
+     *
+     * @param oldSelection The old/previous selection
+     */
+    private void updateOldSelection(ListWidgetSelection<E> oldSelection) {
+        // deselect the old element
+        Optional.ofNullable(oldSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int oldValueIndex = getControl().getElements().indexOf(selection);
+
+            IconsListElement<E> oldElement = mappedElements.get(oldValueIndex);
+
+            oldElement.setSelected(false);
+        });
+    }
+
+    /**
+     * Select the current/new selection
+     *
+     * @param newSelection The current/new selection
+     */
+    private void updateNewSelection(ListWidgetSelection<E> newSelection) {
+        // select the new element
+        Optional.ofNullable(newSelection).map(ListWidgetSelection::getSelection).ifPresent(selection -> {
+            final int newValueIndex = getControl().getElements().indexOf(selection);
+
+            IconsListElement<E> newElement = mappedElements.get(newValueIndex);
+
+            newElement.setSelected(true);
+        });
     }
 }


### PR DESCRIPTION
This PR fixes a bug where a list widget (a) doesn't show a selection, if the selection was has been performed in another list widget (b) before (a) has been opened once.