### PR TITLE
Add a concatenated observable list implementation

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
@@ -1,0 +1,287 @@
+package org.phoenicis.javafx.collections;
+
+import com.google.common.collect.ImmutableList;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import org.phoenicis.javafx.collections.change.InitialisationChange;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ConcatenatedList<E> extends PhoenicisTransformationList<E, ObservableList<E>> {
+    private final List<List<E>> expandedValues;
+
+    public ConcatenatedList(ObservableList<? extends ObservableList<E>> source) {
+        super(source);
+
+        this.expandedValues = source.stream().map(ArrayList::new).collect(Collectors.toList());
+
+        source.forEach(this::addUpdateListener);
+        fireChange(new InitialisationChange<>(0, size(), this));
+    }
+
+    @SafeVarargs
+    public static <F> ConcatenatedList<F> createPrefixList(ObservableList<F> list, F... prefixes) {
+        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+                ImmutableList.<ObservableList<F>> builder()
+                        .add(FXCollections.observableArrayList(prefixes))
+                        .add(list).build()));
+    }
+
+    @SafeVarargs
+    public static <F> ConcatenatedList<F> createSuffixList(ObservableList<F> list, F... suffixes) {
+        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+                ImmutableList.<ObservableList<F>> builder()
+                        .add(list)
+                        .add(FXCollections.observableArrayList(suffixes)).build()));
+    }
+
+    @SafeVarargs
+    public static <F> ConcatenatedList<F> create(ObservableList<F>... lists) {
+        return new ConcatenatedList<F>(FXCollections.observableArrayList(lists));
+    }
+
+    @SafeVarargs
+    public static <F> ConcatenatedList<F> create(List<F>... lists) {
+        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+                Arrays.stream(lists).map(FXCollections::observableArrayList).collect(Collectors.toList())));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getSourceIndex(int index) {
+        if (index < 0 || index >= size()) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        int sum = 0;
+        int sourceIndex = -1;
+
+        for (List<E> innerList : expandedValues) {
+            if (index < sum) {
+                break;
+            }
+
+            sum += innerList.size();
+            sourceIndex++;
+        }
+
+        return sourceIndex;
+    }
+
+    /**
+     * Finds the index of the first element in the source list at the given index position
+     *
+     * @param index The index in the source list
+     * @return The index of the first element of the source index in this list
+     * @apiNote This method is required to make Phoenicis compile with Java 9
+     */
+    public int getViewIndex(int index) {
+        return getFirstIndex(index);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public E get(int index) {
+        if (index < 0 || index >= size()) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        E result = null;
+        int start = 0;
+
+        for (List<E> innerList : expandedValues) {
+            if (start + innerList.size() > index) {
+                result = innerList.get(index - start);
+
+                break;
+            } else {
+                start += innerList.size();
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public int size() {
+        return expandedValues.stream().mapToInt(List::size).sum();
+    }
+
+    /**
+     * Gets the first index in the target list belonging to an item in the list marked by the given
+     * <code>sourceIndex</code>
+     *
+     * @param sourceIndex The index marking a list in the source list
+     * @return The first index in the target list belonging to an item in the list marked by <code>sourceIndex</code>
+     */
+    private int getFirstIndex(int sourceIndex) {
+        int position = 0;
+
+        for (int i = 0; i < sourceIndex; i++) {
+            final List<E> innerList = expandedValues.get(i);
+
+            position += innerList.size();
+        }
+
+        return position;
+    }
+
+    /**
+     * Gets the last index in the target list belonging to an item in the list marked by the given
+     * <code>sourceIndex</code>
+     *
+     * @param sourceIndex The index marking a list in the source list
+     * @return The last index in the target list belonging to an item in the list marked by <code>sourceIndex</code>
+     */
+    private int getLastIndexPlusOne(int sourceIndex) {
+        int position = 0;
+
+        for (int i = 0; i <= sourceIndex; i++) {
+            final List<E> innerList = expandedValues.get(i);
+
+            position += innerList.size();
+        }
+
+        return position;
+    }
+
+    @Override
+    protected void permute(ListChangeListener.Change<? extends ObservableList<E>> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        int expandedFrom = getFirstIndex(from);
+        int expandedTo = getLastIndexPlusOne(to - 1);
+
+        if (to > from) {
+            List<E> beforePermutation = expandedValues.stream().flatMap(List::stream).collect(Collectors.toList());
+            List<List<E>> valuesClone = new ArrayList<>(expandedValues);
+
+            for (int i = from; i < to; ++i) {
+                valuesClone.set(i, expandedValues.get(c.getPermutation(i)));
+            }
+
+            this.expandedValues.clear();
+            this.expandedValues.addAll(valuesClone);
+
+            List<E> afterPermutation = expandedValues.stream().flatMap(List::stream).collect(Collectors.toList());
+
+            int[] perm = beforePermutation.stream()
+                    .mapToInt(afterPermutation::indexOf).toArray();
+
+            nextPermutation(expandedFrom, expandedTo, perm);
+        }
+    }
+
+    @Override
+    protected void update(ListChangeListener.Change<? extends ObservableList<E>> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        if (to > from) {
+            for (int i = from; i < to; ++i) {
+                int firstOldIndex = getFirstIndex(i);
+
+                List<E> oldValues = expandedValues.get(i);
+
+                ObservableList<E> newValues = getSource().get(i);
+
+                expandedValues.set(i, new ArrayList<>(newValues));
+
+                addUpdateListener(newValues);
+
+                // more values were removed than added
+                if (oldValues.size() > newValues.size()) {
+                    for (int count = 0; count < newValues.size(); count++) {
+                        nextUpdate(firstOldIndex + count);
+                    }
+
+                    nextRemove(firstOldIndex, oldValues.subList(newValues.size(), oldValues.size()));
+                }
+
+                // more values were added than removed
+                if (oldValues.size() < newValues.size()) {
+                    for (int count = 0; count < oldValues.size(); count++) {
+                        nextUpdate(firstOldIndex + count);
+                    }
+
+                    nextAdd(firstOldIndex + oldValues.size(), firstOldIndex + newValues.size());
+                }
+
+                // all old values were replaces
+                if (oldValues.size() == newValues.size()) {
+                    for (int count = 0; count < oldValues.size(); count++) {
+                        nextUpdate(firstOldIndex + count);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void addRemove(ListChangeListener.Change<? extends ObservableList<E>> c) {
+        int from = c.getFrom();
+
+        for (int index = from + c.getRemovedSize() - 1; index >= from; index--) {
+            int firstOldIndex = getFirstIndex(index);
+
+            nextRemove(firstOldIndex, expandedValues.remove(index));
+        }
+
+        for (int index = from; index < from + c.getAddedSize(); index++) {
+            int lastOldIndex = getLastIndexPlusOne(index - 1);
+
+            ObservableList<E> newValues = getSource().get(index);
+
+            expandedValues.add(index, new ArrayList<>(newValues));
+
+            addUpdateListener(newValues);
+
+            nextAdd(lastOldIndex, lastOldIndex + newValues.size());
+        }
+    }
+
+    private void addUpdateListener(final ObservableList<E> innerList) {
+        innerList.addListener((ListChangeListener.Change<? extends E> change) -> {
+            ObservableList<? extends E> activatorList = change.getList();
+
+            beginChange();
+            while (change.next()) {
+                final int activatorListIndex = getSource().indexOf(innerList);
+
+                if (change.wasPermutated()) {
+                    int expandedFrom = getFirstIndex(activatorListIndex);
+
+                    expandedValues.set(activatorListIndex, new ArrayList<>(activatorList));
+
+                    nextPermutation(expandedFrom + change.getFrom(), expandedFrom + change.getTo(),
+                            IntStream.range(change.getFrom(), change.getTo()).map(change::getPermutation).toArray());
+                } else if (change.wasUpdated()) {
+                    int expandedFrom = getFirstIndex(activatorListIndex);
+
+                    expandedValues.set(activatorListIndex, new ArrayList<>(activatorList));
+
+                    IntStream.range(expandedFrom + change.getFrom(), expandedFrom + change.getTo())
+                            .forEach(this::nextUpdate);
+                } else {
+                    int expandedFrom = getFirstIndex(activatorListIndex);
+
+                    expandedValues.set(activatorListIndex, new ArrayList<>(activatorList));
+
+                    nextRemove(expandedFrom + change.getFrom(), change.getRemoved());
+                    nextAdd(expandedFrom + change.getFrom(), expandedFrom + change.getFrom() + change.getAddedSize());
+                }
+            }
+            endChange();
+        });
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
@@ -49,7 +49,7 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
      */
     @SafeVarargs
     public static <F> ConcatenatedList<F> createPrefixList(ObservableList<F> list, F... prefixes) {
-        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+        return new ConcatenatedList<>(FXCollections.observableArrayList(
                 ImmutableList.<ObservableList<F>> builder()
                         .add(FXCollections.observableArrayList(prefixes))
                         .add(list).build()));
@@ -66,7 +66,7 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
      */
     @SafeVarargs
     public static <F> ConcatenatedList<F> createSuffixList(ObservableList<F> list, F... suffixes) {
-        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+        return new ConcatenatedList<>(FXCollections.observableArrayList(
                 ImmutableList.<ObservableList<F>> builder()
                         .add(list)
                         .add(FXCollections.observableArrayList(suffixes)).build()));
@@ -81,7 +81,7 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
      */
     @SafeVarargs
     public static <F> ConcatenatedList<F> create(ObservableList<F>... lists) {
-        return new ConcatenatedList<F>(FXCollections.observableArrayList(lists));
+        return new ConcatenatedList<>(FXCollections.observableArrayList(lists));
     }
 
     /**
@@ -93,7 +93,7 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
      */
     @SafeVarargs
     public static <F> ConcatenatedList<F> create(List<F>... lists) {
-        return new ConcatenatedList<F>(FXCollections.observableArrayList(
+        return new ConcatenatedList<>(FXCollections.observableArrayList(
                 Arrays.stream(lists).map(FXCollections::observableArrayList).collect(Collectors.toList())));
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
@@ -44,8 +44,9 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
     }
 
     /**
-     * Creates a new {@link ConcatenatedList} concatenating the given prefix values and the given {@link ObservableList
-     * list}
+     * Creates a new {@link ConcatenatedList} concatenating the given prefix values and the given
+     * {@link ObservableList list}. In the created {@link ConcatenatedList} the prefix values are in
+     * front of the {@link ObservableList list}
      *
      * @param list The list
      * @param prefixes The prefix values
@@ -62,7 +63,8 @@ public class ConcatenatedList<E> extends PhoenicisTransformationList<E, Observab
 
     /**
      * Creates a new {@link ConcatenatedList} concatenating the given {@link ObservableList list} and the given suffix
-     * values
+     * values. In the created {@link ConcatenatedList} the suffix values are located after the
+     * {@link ObservableList list}
      *
      * @param list The list
      * @param suffixes The suffix values

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
@@ -2,11 +2,9 @@ package org.phoenicis.javafx.views.common.lists;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
-import org.junit.Assert;
 import org.junit.Test;
 import org.phoenicis.javafx.collections.ConcatenatedList;
 
@@ -308,11 +306,11 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.add("23");
 
-        Assert.assertEquals(Arrays.asList("11", "21", "22", "23", "31"), actual);
+        assertEquals(Arrays.asList("11", "21", "22", "23", "31"), actual);
     }
 
     @Test
@@ -328,11 +326,11 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.remove(0);
 
-        Assert.assertEquals(Arrays.asList("11", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "22", "31"), actual);
     }
 
     @Test
@@ -348,11 +346,11 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.set(0, "20");
 
-        Assert.assertEquals(Arrays.asList("11", "20", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "20", "22", "31"), actual);
     }
 
     @Test
@@ -368,10 +366,10 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.setComparator(Comparator.reverseOrder());
 
-        Assert.assertEquals(Arrays.asList("11", "22", "21", "31"), actual);
+        assertEquals(Arrays.asList("11", "22", "21", "31"), actual);
     }
 }

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
@@ -1,0 +1,377 @@
+package org.phoenicis.javafx.views.common.lists;
+
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+import org.junit.Assert;
+import org.junit.Test;
+import org.phoenicis.javafx.collections.ConcatenatedList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConcatenatedListTest {
+    @Test
+    public void testListCreation() {
+        ConcatenatedList<String> expandedList = ConcatenatedList
+                .create(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+    }
+
+    @Test
+    public void testListAdd() {
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList());
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.add(1, FXCollections.observableArrayList("01", "02"));
+
+        assertEquals(5, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("01", expandedList.get(1));
+        assertEquals("02", expandedList.get(2));
+        assertEquals("21", expandedList.get(3));
+        assertEquals("22", expandedList.get(4));
+
+        assertEquals(5, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("01", actual.get(1));
+        assertEquals("02", actual.get(2));
+        assertEquals("21", actual.get(3));
+        assertEquals("22", actual.get(4));
+    }
+
+    @Test
+    public void testListRemove1() {
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList());
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.remove(0);
+
+        assertEquals(2, expandedList.size());
+        assertEquals("21", expandedList.get(0));
+        assertEquals("22", expandedList.get(1));
+
+        assertEquals(2, actual.size());
+        assertEquals("21", actual.get(0));
+        assertEquals("22", actual.get(1));
+    }
+
+    @Test
+    public void testListRemove2() {
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList());
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.remove(1);
+
+        assertEquals(1, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+
+        assertEquals(1, actual.size());
+        assertEquals("11", actual.get(0));
+    }
+
+    @Test
+    public void testListRemove3() {
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList());
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.remove(2);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+    }
+
+    @Test
+    public void testListUpdate1() {
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList());
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.set(2, FXCollections.observableArrayList("31", "32", "33"));
+
+        assertEquals(6, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+        assertEquals("31", expandedList.get(3));
+        assertEquals("32", expandedList.get(4));
+        assertEquals("33", expandedList.get(5));
+
+        assertEquals(6, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+        assertEquals("31", actual.get(3));
+        assertEquals("32", actual.get(4));
+        assertEquals("33", actual.get(5));
+    }
+
+    @Test
+    public void testListUpdate2() {
+        FilteredList<ObservableList<String>> observableList = FXCollections.observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList("31"))
+                .filtered(value -> true);
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(4, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+        assertEquals("31", expandedList.get(3));
+
+        assertEquals(4, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+        assertEquals("31", actual.get(3));
+
+        observableList.setPredicate(value -> value.size() != 1);
+
+        assertEquals(2, expandedList.size());
+        assertEquals("21", expandedList.get(0));
+        assertEquals("22", expandedList.get(1));
+
+        assertEquals(2, actual.size());
+        assertEquals("21", actual.get(0));
+        assertEquals("22", actual.get(1));
+
+        observableList.setPredicate(value -> true);
+
+        assertEquals(4, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+        assertEquals("31", expandedList.get(3));
+
+        assertEquals(4, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+        assertEquals("31", actual.get(3));
+    }
+
+    @Test
+    public void testListPermutation() {
+        SortedList<ObservableList<String>> observableList = FXCollections.<ObservableList<String>> observableArrayList(
+                FXCollections.observableArrayList("11"),
+                FXCollections.observableArrayList("21", "22"),
+                FXCollections.observableArrayList())
+                .sorted(Comparator.comparing(List::size));
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("11", actual.get(0));
+        assertEquals("21", actual.get(1));
+        assertEquals("22", actual.get(2));
+
+        observableList.comparatorProperty().set(Comparator.comparing(o -> ((List<String>) o).size()).reversed());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("21", expandedList.get(0));
+        assertEquals("22", expandedList.get(1));
+        assertEquals("11", expandedList.get(2));
+
+        assertEquals(3, actual.size());
+        assertEquals("21", actual.get(0));
+        assertEquals("22", actual.get(1));
+        assertEquals("11", actual.get(2));
+    }
+
+    @Test
+    public void testInnerListAdd() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+
+        list2.add("23");
+
+        Assert.assertEquals(Arrays.asList("11", "21", "22", "23", "31"), actual);
+    }
+
+    @Test
+    public void testInnerListRemove() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+
+        list2.remove(0);
+
+        Assert.assertEquals(Arrays.asList("11", "22", "31"), actual);
+    }
+
+    @Test
+    public void testInnerListUpdate() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+
+        list2.set(0, "20");
+
+        Assert.assertEquals(Arrays.asList("11", "20", "22", "31"), actual);
+    }
+
+    @Test
+    public void testInnerListPermute() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        SortedList<String> list2 = FXCollections.observableArrayList("21", "22").sorted();
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+
+        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, expandedList);
+
+        Assert.assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
+
+        list2.setComparator(Comparator.reverseOrder());
+
+        Assert.assertEquals(Arrays.asList("11", "22", "21", "31"), actual);
+    }
+}

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
@@ -1,5 +1,6 @@
 package org.phoenicis.javafx.views.common.lists;
 
+import com.google.common.collect.ImmutableList;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -8,10 +9,7 @@ import javafx.collections.transformation.SortedList;
 import org.junit.Test;
 import org.phoenicis.javafx.collections.ConcatenatedList;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,7 +17,7 @@ public class ConcatenatedListTest {
     @Test
     public void testListCreation() {
         ConcatenatedList<String> expandedList = ConcatenatedList
-                .create(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+                .create(Collections.singletonList("11"), Arrays.asList("21", "22"), Collections.emptyList());
         List<String> actual = new ArrayList<>();
 
         Bindings.bindContent(actual, expandedList);
@@ -30,10 +28,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListAdd() {
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList());
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
 
@@ -50,10 +49,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListRemove1() {
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList());
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
 
@@ -70,10 +70,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListRemove2() {
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList());
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
 
@@ -84,16 +85,17 @@ public class ConcatenatedListTest {
 
         observableList.remove(1);
 
-        assertEquals(Arrays.asList("11"), expandedList);
-        assertEquals(Arrays.asList("11"), actual);
+        assertEquals(Collections.singletonList("11"), expandedList);
+        assertEquals(Collections.singletonList("11"), actual);
     }
 
     @Test
     public void testListRemove3() {
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList());
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
 
@@ -110,10 +112,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListUpdate1() {
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList());
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
 
@@ -130,10 +133,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListUpdate2() {
-        FilteredList<ObservableList<String>> observableList = FXCollections.observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList("31"))
+        FilteredList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList("31")).build())
                 .filtered(value -> true);
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
@@ -156,10 +160,11 @@ public class ConcatenatedListTest {
 
     @Test
     public void testListPermutation() {
-        SortedList<ObservableList<String>> observableList = FXCollections.<ObservableList<String>> observableArrayList(
-                FXCollections.observableArrayList("11"),
-                FXCollections.observableArrayList("21", "22"),
-                FXCollections.observableArrayList())
+        SortedList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build())
                 .sorted(Comparator.comparing(List::size));
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
         List<String> actual = new ArrayList<>();
@@ -169,7 +174,7 @@ public class ConcatenatedListTest {
         assertEquals(Arrays.asList("11", "21", "22"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22"), actual);
 
-        observableList.comparatorProperty().set(Comparator.comparing(o -> ((List<String>) o).size()).reversed());
+        observableList.comparatorProperty().set(Comparator.<List<String>, Integer> comparing(List::size).reversed());
 
         assertEquals(Arrays.asList("21", "22", "11"), expandedList);
         assertEquals(Arrays.asList("21", "22", "11"), actual);
@@ -181,7 +186,9 @@ public class ConcatenatedListTest {
         ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
 
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(list1).add(list2).add(list3).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
 
         List<String> actual = new ArrayList<>();
@@ -203,7 +210,9 @@ public class ConcatenatedListTest {
         ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
 
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(list1).add(list2).add(list3).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
 
         List<String> actual = new ArrayList<>();
@@ -225,7 +234,9 @@ public class ConcatenatedListTest {
         ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
 
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(list1).add(list2).add(list3).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
 
         List<String> actual = new ArrayList<>();
@@ -247,7 +258,9 @@ public class ConcatenatedListTest {
         SortedList<String> list2 = FXCollections.observableArrayList("21", "22").sorted();
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
 
-        ObservableList<ObservableList<String>> observableList = FXCollections.observableArrayList(list1, list2, list3);
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>> builder()
+                        .add(list1).add(list2).add(list3).build());
         ConcatenatedList<String> expandedList = new ConcatenatedList<>(observableList);
 
         List<String> actual = new ArrayList<>();

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
@@ -48,7 +48,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testListRemove1() {
+    public void testListRemoveFirstList() {
         ObservableList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>> builder()
                         .add(FXCollections.observableArrayList("11"))
@@ -69,7 +69,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testListRemove2() {
+    public void testListRemoveMiddleList() {
         ObservableList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>> builder()
                         .add(FXCollections.observableArrayList("11"))
@@ -90,7 +90,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testListRemove3() {
+    public void testListRemoveLastList() {
         ObservableList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>> builder()
                         .add(FXCollections.observableArrayList("11"))
@@ -111,7 +111,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testListUpdate1() {
+    public void testListUpdateLastList() {
         ObservableList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>> builder()
                         .add(FXCollections.observableArrayList("11"))
@@ -132,7 +132,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testListUpdate2() {
+    public void testListUpdateViaFilteredList() {
         FilteredList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>> builder()
                         .add(FXCollections.observableArrayList("11"))

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/lists/ConcatenatedListTest.java
@@ -24,15 +24,8 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
     }
 
     @Test
@@ -46,31 +39,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.add(1, FXCollections.observableArrayList("01", "02"));
 
-        assertEquals(5, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("01", expandedList.get(1));
-        assertEquals("02", expandedList.get(2));
-        assertEquals("21", expandedList.get(3));
-        assertEquals("22", expandedList.get(4));
-
-        assertEquals(5, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("01", actual.get(1));
-        assertEquals("02", actual.get(2));
-        assertEquals("21", actual.get(3));
-        assertEquals("22", actual.get(4));
+        assertEquals(Arrays.asList("11", "01", "02", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "01", "02", "21", "22"), actual);
     }
 
     @Test
@@ -84,25 +59,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.remove(0);
 
-        assertEquals(2, expandedList.size());
-        assertEquals("21", expandedList.get(0));
-        assertEquals("22", expandedList.get(1));
-
-        assertEquals(2, actual.size());
-        assertEquals("21", actual.get(0));
-        assertEquals("22", actual.get(1));
+        assertEquals(Arrays.asList("21", "22"), expandedList);
+        assertEquals(Arrays.asList("21", "22"), actual);
     }
 
     @Test
@@ -116,23 +79,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.remove(1);
 
-        assertEquals(1, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-
-        assertEquals(1, actual.size());
-        assertEquals("11", actual.get(0));
+        assertEquals(Arrays.asList("11"), expandedList);
+        assertEquals(Arrays.asList("11"), actual);
     }
 
     @Test
@@ -146,27 +99,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.remove(2);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
     }
 
     @Test
@@ -180,33 +119,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.set(2, FXCollections.observableArrayList("31", "32", "33"));
 
-        assertEquals(6, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-        assertEquals("31", expandedList.get(3));
-        assertEquals("32", expandedList.get(4));
-        assertEquals("33", expandedList.get(5));
-
-        assertEquals(6, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
-        assertEquals("31", actual.get(3));
-        assertEquals("32", actual.get(4));
-        assertEquals("33", actual.get(5));
+        assertEquals(Arrays.asList("11", "21", "22", "31", "32", "33"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22", "31", "32", "33"), actual);
     }
 
     @Test
@@ -221,41 +140,18 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(4, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-        assertEquals("31", expandedList.get(3));
-
-        assertEquals(4, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
-        assertEquals("31", actual.get(3));
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         observableList.setPredicate(value -> value.size() != 1);
 
-        assertEquals(2, expandedList.size());
-        assertEquals("21", expandedList.get(0));
-        assertEquals("22", expandedList.get(1));
-
-        assertEquals(2, actual.size());
-        assertEquals("21", actual.get(0));
-        assertEquals("22", actual.get(1));
+        assertEquals(Arrays.asList("21", "22"), expandedList);
+        assertEquals(Arrays.asList("21", "22"), actual);
 
         observableList.setPredicate(value -> true);
 
-        assertEquals(4, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-        assertEquals("31", expandedList.get(3));
-
-        assertEquals(4, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
-        assertEquals("31", actual.get(3));
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
     }
 
     @Test
@@ -270,27 +166,13 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
-        assertEquals(3, expandedList.size());
-        assertEquals("11", expandedList.get(0));
-        assertEquals("21", expandedList.get(1));
-        assertEquals("22", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("11", actual.get(0));
-        assertEquals("21", actual.get(1));
-        assertEquals("22", actual.get(2));
+        assertEquals(Arrays.asList("11", "21", "22"), expandedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
 
         observableList.comparatorProperty().set(Comparator.comparing(o -> ((List<String>) o).size()).reversed());
 
-        assertEquals(3, expandedList.size());
-        assertEquals("21", expandedList.get(0));
-        assertEquals("22", expandedList.get(1));
-        assertEquals("11", expandedList.get(2));
-
-        assertEquals(3, actual.size());
-        assertEquals("21", actual.get(0));
-        assertEquals("22", actual.get(1));
-        assertEquals("11", actual.get(2));
+        assertEquals(Arrays.asList("21", "22", "11"), expandedList);
+        assertEquals(Arrays.asList("21", "22", "11"), actual);
     }
 
     @Test
@@ -306,10 +188,12 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.add("23");
 
+        assertEquals(Arrays.asList("11", "21", "22", "23", "31"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22", "23", "31"), actual);
     }
 
@@ -326,10 +210,12 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.remove(0);
 
+        assertEquals(Arrays.asList("11", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "22", "31"), actual);
     }
 
@@ -346,10 +232,12 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.set(0, "20");
 
+        assertEquals(Arrays.asList("11", "20", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "20", "22", "31"), actual);
     }
 
@@ -366,10 +254,12 @@ public class ConcatenatedListTest {
 
         Bindings.bindContent(actual, expandedList);
 
+        assertEquals(Arrays.asList("11", "21", "22", "31"), expandedList);
         assertEquals(Arrays.asList("11", "21", "22", "31"), actual);
 
         list2.setComparator(Comparator.reverseOrder());
 
+        assertEquals(Arrays.asList("11", "22", "21", "31"), expandedList);
         assertEquals(Arrays.asList("11", "22", "21", "31"), actual);
     }
 }


### PR DESCRIPTION
This PR adds a `ConcatenatedList` class to Phoenicis, which fixes #1565.
The new `ConcatenatedList` class changes in the number of lists it concatenates and in the concatenated lists themselves. 