### PR TITLE
Remove unused maven-replacer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,28 +214,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <file>${project.root}/i18n/keys.pot</file>
-                    <replacements>
-                        <replacement>
-                            <token>"POT-Creation-Date: \d{4}-\d{2}-\d{2} \d{2}:\d{2}\+\d{4}\\n"</token>
-                            <value>"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\\n"</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>


### PR DESCRIPTION
The keys.pot is not updated during the Maven build anymore.