### PR TITLE
Add pulseaudio permission to flatpak

### DIFF
--- a/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
+++ b/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
@@ -37,6 +37,7 @@ finish-args:
   - --allow=multiarch
   - --share=ipc
   - --socket=x11
+  - --socket=pulseaudio
   - --share=network
   - --device=dri
 modules:


### PR DESCRIPTION
Pulseaudio socket is needed to support audio output/input in flatpak installation.
This fixes #1840 