### PR TITLE
Relax flatpak device permissions for controller access

### DIFF
--- a/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
+++ b/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
@@ -38,7 +38,7 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --share=network
-  - --device=dri
+  - --device=all
 modules:
   - name: openjdk
     buildsystem: simple


### PR DESCRIPTION
I just read the flatpak documentation about [Sandbox Permissions](http://docs.flatpak.org/en/latest/sandbox-permissions.html). Here is written:
```
While not ideal, --device=all can be used to access devices like controllers or webcams.
```
I have not tested this yet, but missing controller support would probably have been noticed sooner or later.