### PR TITLE
Improve applications components

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationSidebar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationSidebar.java
@@ -2,10 +2,14 @@ package org.phoenicis.javafx.components.application.control;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
 import org.phoenicis.javafx.components.application.skin.ApplicationSidebarSkin;
 import org.phoenicis.javafx.components.common.control.ExtendedSidebarBase;
 import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetType;
+import org.phoenicis.javafx.utils.BooleanBindings;
+import org.phoenicis.javafx.utils.ObjectBindings;
+import org.phoenicis.javafx.utils.StringBindings;
 import org.phoenicis.javafx.views.mainwindow.apps.ApplicationFilter;
 import org.phoenicis.repository.dto.CategoryDTO;
 
@@ -41,7 +45,7 @@ public class ApplicationSidebar extends ExtendedSidebarBase<CategoryDTO, Applica
     /**
      * An application filter utility class
      */
-    private final ApplicationFilter filter;
+    private final ObjectProperty<ApplicationFilter> filter;
 
     /**
      * Constructor
@@ -50,17 +54,25 @@ public class ApplicationSidebar extends ExtendedSidebarBase<CategoryDTO, Applica
      * @param items The items shown inside a toggle button group in the sidebar
      * @param selectedListWidget The currently selected {@link ListWidgetType} by the user
      */
-    public ApplicationSidebar(ApplicationFilter filter, ObservableList<CategoryDTO> items,
+    private ApplicationSidebar(ObjectProperty<ApplicationFilter> filter, ObservableList<CategoryDTO> items,
             ObjectProperty<ListWidgetType> selectedListWidget) {
-        super(items, filter.filterTextProperty(), selectedListWidget);
+        super(items, StringBindings.mutableMap(filter, ApplicationFilter::filterTextProperty), selectedListWidget);
 
         this.filter = filter;
 
-        this.filterCategory = filter.filterCategoryProperty();
-        this.containCommercialApplications = filter.containCommercialApplicationsProperty();
-        this.containRequiresPatchApplications = filter.containRequiresPatchApplicationsProperty();
-        this.containTestingApplications = filter.containTestingApplicationsProperty();
-        this.containAllOSCompatibleApplications = filter.containAllOSCompatibleApplicationsProperty();
+        this.filterCategory = ObjectBindings.mutableMap(filter, ApplicationFilter::filterCategoryProperty);
+        this.containCommercialApplications = BooleanBindings.mutableMap(filter,
+                ApplicationFilter::containCommercialApplicationsProperty);
+        this.containRequiresPatchApplications = BooleanBindings.mutableMap(filter,
+                ApplicationFilter::containRequiresPatchApplicationsProperty);
+        this.containTestingApplications = BooleanBindings.mutableMap(filter,
+                ApplicationFilter::containTestingApplicationsProperty);
+        this.containAllOSCompatibleApplications = BooleanBindings.mutableMap(filter,
+                ApplicationFilter::containAllOSCompatibleApplicationsProperty);
+    }
+
+    public ApplicationSidebar(ObservableList<CategoryDTO> items) {
+        this(new SimpleObjectProperty<>(), items, new SimpleObjectProperty<>());
     }
 
     /**
@@ -132,6 +144,14 @@ public class ApplicationSidebar extends ExtendedSidebarBase<CategoryDTO, Applica
     }
 
     public ApplicationFilter getFilter() {
+        return filter.get();
+    }
+
+    public ObjectProperty<ApplicationFilter> filterProperty() {
         return filter;
+    }
+
+    public void setFilter(ApplicationFilter filter) {
+        this.filter.set(filter);
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationSidebar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationSidebar.java
@@ -56,7 +56,7 @@ public class ApplicationSidebar extends ExtendedSidebarBase<CategoryDTO, Applica
      */
     private ApplicationSidebar(ObjectProperty<ApplicationFilter> filter, ObservableList<CategoryDTO> items,
             ObjectProperty<ListWidgetType> selectedListWidget) {
-        super(items, StringBindings.mutableMap(filter, ApplicationFilter::filterTextProperty), selectedListWidget);
+        super(items, StringBindings.mutableMap(filter, ApplicationFilter::searchTermProperty), selectedListWidget);
 
         this.filter = filter;
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
@@ -1,5 +1,6 @@
 package org.phoenicis.javafx.components.application.skin;
 
+import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.transformation.FilteredList;
@@ -41,6 +42,7 @@ public class ApplicationSidebarSkin
 
         filteredCategories.predicateProperty().bind(
                 Bindings.createObjectBinding(() -> getControl().getFilter()::filter,
+                        getControl().filterProperty(),
                         getControl().searchTermProperty(),
                         getControl().containAllOSCompatibleApplicationsProperty(),
                         getControl().containCommercialApplicationsProperty(),

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
@@ -3,6 +3,7 @@ package org.phoenicis.javafx.components.application.skin;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ScrollPane;
@@ -10,6 +11,8 @@ import org.phoenicis.javafx.components.application.control.ApplicationSidebar;
 import org.phoenicis.javafx.components.application.control.ApplicationSidebarToggleGroup;
 import org.phoenicis.javafx.components.common.control.SidebarGroup;
 import org.phoenicis.javafx.components.common.skin.ExtendedSidebarSkinBase;
+import org.phoenicis.javafx.utils.CollectionBindings;
+import org.phoenicis.javafx.views.mainwindow.apps.ApplicationFilter;
 import org.phoenicis.repository.dto.CategoryDTO;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
@@ -37,17 +40,9 @@ public class ApplicationSidebarSkin
     }
 
     private ApplicationSidebarToggleGroup createSidebarToggleGroup() {
-        final FilteredList<CategoryDTO> filteredCategories = getControl().getItems()
-                .filtered(getControl().getFilter()::filter);
-
-        filteredCategories.predicateProperty().bind(
-                Bindings.createObjectBinding(() -> getControl().getFilter()::filter,
-                        getControl().filterProperty(),
-                        getControl().searchTermProperty(),
-                        getControl().containAllOSCompatibleApplicationsProperty(),
-                        getControl().containCommercialApplicationsProperty(),
-                        getControl().containRequiresPatchApplicationsProperty(),
-                        getControl().containTestingApplicationsProperty()));
+        final ObservableList<CategoryDTO> filteredCategories = CollectionBindings
+                .mapToObservableList(getControl().filterProperty(),
+                        filter -> filter.createFilteredList(getControl().getItems()));
 
         return new ApplicationSidebarToggleGroup(tr("Categories"),
                 filteredCategories, getControl().filterCategoryProperty());

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarSkin.java
@@ -1,10 +1,8 @@
 package org.phoenicis.javafx.components.application.skin;
 
-import javafx.beans.Observable;
-import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ScrollPane;
 import org.phoenicis.javafx.components.application.control.ApplicationSidebar;
@@ -12,7 +10,7 @@ import org.phoenicis.javafx.components.application.control.ApplicationSidebarTog
 import org.phoenicis.javafx.components.common.control.SidebarGroup;
 import org.phoenicis.javafx.components.common.skin.ExtendedSidebarSkinBase;
 import org.phoenicis.javafx.utils.CollectionBindings;
-import org.phoenicis.javafx.views.mainwindow.apps.ApplicationFilter;
+import org.phoenicis.javafx.utils.ObjectBindings;
 import org.phoenicis.repository.dto.CategoryDTO;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
@@ -22,6 +20,8 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
  */
 public class ApplicationSidebarSkin
         extends ExtendedSidebarSkinBase<CategoryDTO, ApplicationSidebar, ApplicationSidebarSkin> {
+    private final ObjectBinding<ObservableList<CategoryDTO>> filteredCategories;
+
     /**
      * Constructor
      *
@@ -29,6 +29,9 @@ public class ApplicationSidebarSkin
      */
     public ApplicationSidebarSkin(ApplicationSidebar control) {
         super(control);
+
+        this.filteredCategories = ObjectBindings.map(getControl().filterProperty(),
+                filter -> filter.createFilteredList(getControl().getItems()));
     }
 
     /**
@@ -40,9 +43,7 @@ public class ApplicationSidebarSkin
     }
 
     private ApplicationSidebarToggleGroup createSidebarToggleGroup() {
-        final ObservableList<CategoryDTO> filteredCategories = CollectionBindings
-                .mapToObservableList(getControl().filterProperty(),
-                        filter -> filter.createFilteredList(getControl().getItems()));
+        final ObservableList<CategoryDTO> filteredCategories = CollectionBindings.flatMap(this.filteredCategories);
 
         return new ApplicationSidebarToggleGroup(tr("Categories"),
                 filteredCategories, getControl().filterCategoryProperty());

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/BooleanBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/BooleanBindings.java
@@ -4,10 +4,11 @@ import com.sun.javafx.binding.Logging;
 import com.sun.javafx.collections.ImmutableObservableList;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
-import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -15,50 +16,46 @@ import javafx.collections.ObservableList;
 import java.util.Optional;
 import java.util.function.Function;
 
-/**
- * A utility class containing functions to map {@link ObservableValue} objects to {@link ObservableValue} objects
- */
-public class ObjectBindings {
+public class BooleanBindings {
     /**
-     * Maps a {@link ObservableValue<I>} object to a {@link ObjectBinding<O>} by applying the given converter function.
+     * Maps a {@link ObservableValue} object to a {@link BooleanBinding} by applying the given converter function.
      * In case the input value is empty, i.e. contains <code>null</code>, the given default value is used
      *
      * @param property The input value
      * @param converter The converter function
      * @param defaultValue The default value in case the input value is empty
-     * @param <I> The type of the input value
-     * @param <O> The type of the output value
-     * @return A {@link ObjectBinding} containing the converted value
+     * @param <E> The type of the input value
+     * @return A {@link BooleanBinding} containing the converted value
      */
-    public static <I, O> ObjectBinding<O> map(ObservableValue<I> property, Function<I, O> converter, O defaultValue) {
-        return Bindings.createObjectBinding(
+    public static <E> BooleanBinding map(ObservableValue<E> property, Function<E, Boolean> converter,
+            boolean defaultValue) {
+        return Bindings.createBooleanBinding(
                 () -> Optional.ofNullable(property.getValue()).map(converter).orElse(defaultValue), property);
     }
 
     /**
-     * Maps a {@link ObservableValue<I>} object to a {@link ObjectBinding<O>} by applying the given converter function
+     * Maps a {@link ObservableValue} object to a {@link BooleanBinding} by applying the given converter function
      *
      * @param property The input value
      * @param converter The converter function
-     * @param <I> The type of the input value
-     * @param <O> The type of the output value
-     * @return A {@link ObjectBinding} containing the converted value
+     * @param <E> The type of the input value
+     * @return A {@link BooleanBinding} containing the converted value
      */
-    public static <I, O> ObjectBinding<O> map(ObservableValue<I> property, Function<I, O> converter) {
-        return map(property, converter, null);
+    public static <E> BooleanBinding map(ObservableValue<E> property, Function<E, Boolean> converter) {
+        return map(property, converter, false);
     }
 
-    public static <I, O> ObjectBinding<O> flatMap(ObservableValue<I> property,
-            Function<I, ObservableValue<O>> converter, O defaultValue) {
-        return new ObjectBinding<O>() {
-            private ObservableValue<O> currentValue;
+    public static <E> BooleanBinding flatMap(ObservableValue<E> property,
+            Function<E, ObservableValue<Boolean>> converter, boolean defaultValue) {
+        return new BooleanBinding() {
+            private ObservableValue<Boolean> currentValue;
 
             {
                 bind(property);
             }
 
             @Override
-            protected O computeValue() {
+            protected boolean computeValue() {
                 try {
                     if (currentValue != null) {
                         super.unbind(currentValue);
@@ -66,7 +63,8 @@ public class ObjectBindings {
                         this.currentValue = null;
                     }
 
-                    ObservableValue<O> value = Optional.ofNullable(property.getValue()).map(converter).orElse(null);
+                    ObservableValue<Boolean> value = Optional.ofNullable(property.getValue()).map(converter)
+                            .orElse(null);
 
                     if (value != null) {
                         this.currentValue = value;
@@ -99,15 +97,16 @@ public class ObjectBindings {
         };
     }
 
-    public static <I, O> ObjectBinding<O> flatMap(ObservableValue<I> property,
-            Function<I, ObservableValue<O>> converter) {
-        return flatMap(property, converter, null);
+    public static <E> BooleanBinding flatMap(ObservableValue<E> property,
+            Function<E, ObservableValue<Boolean>> converter) {
+        return flatMap(property, converter, false);
     }
 
-    public static <I, O> ObjectProperty<O> mutableMap(ObservableValue<I> property, Function<I, Property<O>> converter) {
-        final ObjectProperty<O> result = new SimpleObjectProperty<>();
+    public static <E> BooleanProperty mutableMap(ObservableValue<E> property,
+            Function<E, Property<Boolean>> converter) {
+        final BooleanProperty result = new SimpleBooleanProperty();
 
-        final ObjectBinding<Property<O>> mapping = ObjectBindings.map(property, converter);
+        final ObjectBinding<Property<Boolean>> mapping = ObjectBindings.map(property, converter);
 
         mapping.addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/BooleanBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/BooleanBindings.java
@@ -110,15 +110,15 @@ public class BooleanBindings {
 
         mapping.addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                oldValue.unbindBidirectional(result);
+                result.unbindBidirectional(oldValue);
             }
 
             if (newValue != null) {
-                newValue.bindBidirectional(result);
+                result.bindBidirectional(newValue);
             }
         });
 
-        Optional.ofNullable(mapping.getValue()).ifPresent(newValue -> newValue.bindBidirectional(result));
+        Optional.ofNullable(mapping.getValue()).ifPresent(result::bindBidirectional);
 
         return result;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
@@ -1,11 +1,14 @@
 package org.phoenicis.javafx.utils;
 
 import javafx.beans.Observable;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -37,6 +40,29 @@ public class CollectionBindings {
                 result.clear();
             }
         });
+
+        return result;
+    }
+
+    public static <I, O> ObservableList<O> mapToObservableList(ObservableValue<I> property,
+            Function<I, ? extends ObservableList<O>> converter) {
+        final ObservableList<O> result = FXCollections.observableArrayList();
+
+        final ObjectBinding<? extends ObservableList<O>> mapping = ObjectBindings.map(property, converter);
+
+        mapping.addListener((observable, oldList, newList) -> {
+            if (oldList != null) {
+                Bindings.unbindContent(result, oldList);
+            }
+
+            if (newList != null) {
+                Bindings.bindContent(result, newList);
+            } else {
+                result.clear();
+            }
+        });
+
+        Optional.ofNullable(mapping.getValue()).ifPresent(newList -> Bindings.bindContent(result, newList));
 
         return result;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
@@ -44,13 +44,10 @@ public class CollectionBindings {
         return result;
     }
 
-    public static <I, O> ObservableList<O> mapToObservableList(ObservableValue<I> property,
-            Function<I, ? extends ObservableList<O>> converter) {
+    public static <O> ObservableList<O> flatMap(ObservableValue<? extends ObservableList<O>> property) {
         final ObservableList<O> result = FXCollections.observableArrayList();
 
-        final ObjectBinding<? extends ObservableList<O>> mapping = ObjectBindings.map(property, converter);
-
-        mapping.addListener((observable, oldList, newList) -> {
+        property.addListener((observable, oldList, newList) -> {
             if (oldList != null) {
                 Bindings.unbindContent(result, oldList);
             }
@@ -62,7 +59,7 @@ public class CollectionBindings {
             }
         });
 
-        Optional.ofNullable(mapping.getValue()).ifPresent(newList -> Bindings.bindContent(result, newList));
+        Optional.ofNullable(property.getValue()).ifPresent(newList -> Bindings.bindContent(result, newList));
 
         return result;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/ObjectBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/ObjectBindings.java
@@ -111,15 +111,15 @@ public class ObjectBindings {
 
         mapping.addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                oldValue.unbindBidirectional(result);
+                result.unbindBidirectional(oldValue);
             }
 
             if (newValue != null) {
-                newValue.bindBidirectional(result);
+                result.bindBidirectional(newValue);
             }
         });
 
-        Optional.ofNullable(mapping.getValue()).ifPresent(newValue -> newValue.bindBidirectional(result));
+        Optional.ofNullable(mapping.getValue()).ifPresent(result::bindBidirectional);
 
         return result;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/StringBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/StringBindings.java
@@ -1,8 +1,17 @@
 package org.phoenicis.javafx.utils;
 
+import com.sun.javafx.binding.Logging;
+import com.sun.javafx.collections.ImmutableObservableList;
+import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
 import javafx.beans.binding.StringBinding;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -37,5 +46,82 @@ public final class StringBindings {
      */
     public static <E> StringBinding map(ObservableValue<E> property, Function<E, String> converter) {
         return map(property, converter, null);
+    }
+
+    public static <E> StringBinding flatMap(ObservableValue<E> property, Function<E, ObservableValue<String>> converter,
+            String defaultValue) {
+        return new StringBinding() {
+            private ObservableValue<String> currentValue;
+
+            {
+                bind(property);
+            }
+
+            @Override
+            protected String computeValue() {
+                try {
+                    if (currentValue != null) {
+                        super.unbind(currentValue);
+
+                        this.currentValue = null;
+                    }
+
+                    ObservableValue<String> value = Optional.ofNullable(property.getValue()).map(converter)
+                            .orElse(null);
+
+                    if (value != null) {
+                        this.currentValue = value;
+
+                        bind(currentValue);
+                    }
+
+                    return Optional.ofNullable(value).map(ObservableValue::getValue).orElse(defaultValue);
+                } catch (Exception e) {
+                    Logging.getLogger().warning("Exception while evaluating binding", e);
+
+                    return defaultValue;
+                }
+            }
+
+            @Override
+            public void dispose() {
+                if (currentValue != null) {
+                    super.unbind(currentValue);
+                }
+
+                super.unbind(property);
+            }
+
+            @Override
+            public ObservableList<?> getDependencies() {
+                return currentValue == null ? FXCollections.singletonObservableList(property)
+                        : new ImmutableObservableList<Observable>(property, currentValue);
+            }
+        };
+    }
+
+    public static <E> StringBinding flatMap(ObservableValue<E> property,
+            Function<E, ObservableValue<String>> converter) {
+        return flatMap(property, converter, null);
+    }
+
+    public static <E> StringProperty mutableMap(ObservableValue<E> property, Function<E, Property<String>> converter) {
+        final StringProperty result = new SimpleStringProperty();
+
+        final ObjectBinding<Property<String>> mapping = ObjectBindings.map(property, converter);
+
+        mapping.addListener((observable, oldValue, newValue) -> {
+            if (oldValue != null) {
+                oldValue.unbindBidirectional(result);
+            }
+
+            if (newValue != null) {
+                newValue.bindBidirectional(result);
+            }
+        });
+
+        Optional.ofNullable(mapping.getValue()).ifPresent(newValue -> newValue.bindBidirectional(result));
+
+        return result;
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/StringBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/StringBindings.java
@@ -112,15 +112,15 @@ public final class StringBindings {
 
         mapping.addListener((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                oldValue.unbindBidirectional(result);
+                result.unbindBidirectional(oldValue);
             }
 
             if (newValue != null) {
-                newValue.bindBidirectional(result);
+                result.bindBidirectional(newValue);
             }
         });
 
-        Optional.ofNullable(mapping.getValue()).ifPresent(newValue -> newValue.bindBidirectional(result));
+        Optional.ofNullable(mapping.getValue()).ifPresent(result::bindBidirectional);
 
         return result;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
@@ -149,7 +149,7 @@ public class ApplicationsView extends MainWindowView<ApplicationSidebar> {
 
         filteredApplications.predicateProperty().bind(
                 Bindings.createObjectBinding(() -> this.filter::filter,
-                        this.filter.filterTextProperty(), this.filter.filterCategoryProperty(),
+                        this.filter.searchTermProperty(), this.filter.filterCategoryProperty(),
                         this.filter.containAllOSCompatibleApplicationsProperty(),
                         this.filter.containCommercialApplicationsProperty(),
                         this.filter.containRequiresPatchApplicationsProperty(),

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationsView.java
@@ -181,7 +181,11 @@ public class ApplicationsView extends MainWindowView<ApplicationSidebar> {
                 .filtered(category -> category.getType() == CategoryDTO.CategoryType.INSTALLERS)
                 .sorted(Comparator.comparing(CategoryDTO::getName));
 
-        final ApplicationSidebar sidebar = new ApplicationSidebar(filter, sortedCategories, selectedListWidget);
+        final ApplicationSidebar sidebar = new ApplicationSidebar(sortedCategories);
+
+        sidebar.setFilter(filter);
+
+        sidebar.selectedListWidgetProperty().bindBidirectional(selectedListWidget);
 
         // set the default selection
         sidebar.setSelectedListWidget(javaFxSettingsManager.getAppsListType());


### PR DESCRIPTION
This PR introduces some new utility methods which can be used together with `Binding` and `Property` objects:
- `flatMap`
- `mutableMap`

In addition the PR adds a new utility class for `BooleanBinding` objects called `BooleanBindings`.

I'm still thinking about whether we should merge this PR at all, because on one hand the suggested extensions to the binding and property utility classes are useful, but on the other hand they are hard to debug and add an additional complexity layer.

@qparis @plata what do you think?

Currently this PR is still WIP and should not be merged.