### PR TITLE
Refactor some JavaFX components

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerEngineSettingsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerEngineSettingsPanel.java
@@ -33,25 +33,13 @@ public class ContainerEngineSettingsPanel
 
     /**
      * Constructor
-     *
-     * @param container The container
-     * @param engineSettings A list of all engine settings
-     * @param lockEngineSettings A boolean signifying whether all engine settings buttons should be locked
-     */
-    public ContainerEngineSettingsPanel(ObjectProperty<ContainerDTO> container,
-            ObservableList<EngineSetting> engineSettings, BooleanProperty lockEngineSettings) {
-        super();
-
-        this.container = container;
-        this.engineSettings = engineSettings;
-        this.lockEngineSettings = lockEngineSettings;
-    }
-
-    /**
-     * Constructor
      */
     public ContainerEngineSettingsPanel() {
-        this(new SimpleObjectProperty<>(), FXCollections.observableArrayList(), new SimpleBooleanProperty());
+        super();
+
+        this.container = new SimpleObjectProperty<>();
+        this.engineSettings = FXCollections.observableArrayList();
+        this.lockEngineSettings = new SimpleBooleanProperty();
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerEngineToolsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerEngineToolsPanel.java
@@ -1,16 +1,15 @@
 package org.phoenicis.javafx.components.container.control;
 
-import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.phoenicis.containers.dto.ContainerDTO;
 import org.phoenicis.engines.EngineToolsManager;
 import org.phoenicis.javafx.components.common.control.ControlBase;
 import org.phoenicis.javafx.components.container.skin.ContainerEngineToolsPanelSkin;
+import org.phoenicis.javafx.utils.CollectionBindings;
 import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.ScriptDTO;
 
@@ -45,51 +44,16 @@ public class ContainerEngineToolsPanel extends ControlBase<ContainerEngineToolsP
 
     /**
      * Constructor
-     *
-     * @param container The container
-     * @param engineTools The application containing the tool scripts
-     * @param engineToolsManager The engine tools manager
-     * @param lockTools A boolean signifying whether all tool buttons should be locked
-     */
-    public ContainerEngineToolsPanel(ObjectProperty<ContainerDTO> container, ObjectProperty<ApplicationDTO> engineTools,
-            ObjectProperty<EngineToolsManager> engineToolsManager, BooleanProperty lockTools) {
-        super();
-
-        this.container = container;
-        this.engineTools = engineTools;
-        this.engineToolsManager = engineToolsManager;
-        this.lockTools = lockTools;
-
-        this.engineToolScripts = createEngineToolScripts();
-    }
-
-    /**
-     * Constructor
      */
     public ContainerEngineToolsPanel() {
-        this(new SimpleObjectProperty<>(), new SimpleObjectProperty<>(), new SimpleObjectProperty<>(),
-                new SimpleBooleanProperty());
-    }
+        super();
 
-    /**
-     * Creates an {@link ObservableList} containing all tool {@link ScriptDTO}s contained in <code>engineTools</code>
-     *
-     * @return An {@link ObservableList} containing all tool {@link ScriptDTO}s contained in <code>engineTools</code>
-     */
-    private ObservableList<ScriptDTO> createEngineToolScripts() {
-        final ObservableList<ScriptDTO> engineToolScripts = FXCollections.observableArrayList();
+        this.container = new SimpleObjectProperty<>();
+        this.engineTools = new SimpleObjectProperty<>();
+        this.engineToolsManager = new SimpleObjectProperty<>();
+        this.lockTools = new SimpleBooleanProperty();
 
-        engineTools.addListener((Observable invalidation) -> {
-            final ApplicationDTO engineTools = getEngineTools();
-
-            if (engineTools != null) {
-                engineToolScripts.setAll(engineTools.getScripts());
-            } else {
-                engineToolScripts.clear();
-            }
-        });
-
-        return engineToolScripts;
+        this.engineToolScripts = CollectionBindings.mapToList(engineToolsProperty(), ApplicationDTO::getScripts);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerOverviewPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerOverviewPanel.java
@@ -30,27 +30,13 @@ public class ContainerOverviewPanel extends ControlBase<ContainerOverviewPanel, 
 
     /**
      * Constructor
-     *
-     * @param container The selected container
-     * @param onDeleteContainer The callback method which is called when the container should be deleted
-     * @param onOpenFileBrowser The callback method which is called when the container should be opened in a file
-     *            browser
-     */
-    public ContainerOverviewPanel(ObjectProperty<WinePrefixContainerDTO> container,
-            ObjectProperty<Consumer<ContainerDTO>> onDeleteContainer,
-            ObjectProperty<Consumer<ContainerDTO>> onOpenFileBrowser) {
-        super();
-
-        this.container = container;
-        this.onDeleteContainer = onDeleteContainer;
-        this.onOpenFileBrowser = onOpenFileBrowser;
-    }
-
-    /**
-     * Constructor
      */
     public ContainerOverviewPanel() {
-        this(new SimpleObjectProperty<>(), new SimpleObjectProperty<>(), new SimpleObjectProperty<>());
+        super();
+
+        this.container = new SimpleObjectProperty<>();
+        this.onDeleteContainer = new SimpleObjectProperty<>();
+        this.onOpenFileBrowser = new SimpleObjectProperty<>();
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerToolsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerToolsPanel.java
@@ -30,25 +30,13 @@ public class ContainerToolsPanel extends ControlBase<ContainerToolsPanel, Contai
 
     /**
      * Constructor
-     *
-     * @param container The container
-     * @param containerEngineController The container engine controller used to execute a tool inside a container
-     * @param lockTools A boolean signifying whether all tool buttons should be locked
-     */
-    public ContainerToolsPanel(ObjectProperty<ContainerDTO> container,
-            ObjectProperty<ContainerEngineController> containerEngineController, BooleanProperty lockTools) {
-        super();
-
-        this.container = container;
-        this.containerEngineController = containerEngineController;
-        this.lockTools = lockTools;
-    }
-
-    /**
-     * Constructor
      */
     public ContainerToolsPanel() {
-        this(new SimpleObjectProperty<>(), new SimpleObjectProperty<>(), new SimpleBooleanProperty());
+        super();
+
+        this.container = new SimpleObjectProperty<>();
+        this.containerEngineController = new SimpleObjectProperty<>();
+        this.lockTools = new SimpleBooleanProperty();
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
@@ -1,16 +1,15 @@
 package org.phoenicis.javafx.components.container.control;
 
-import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.phoenicis.containers.dto.ContainerDTO;
 import org.phoenicis.engines.VerbsManager;
 import org.phoenicis.javafx.components.common.control.ControlBase;
 import org.phoenicis.javafx.components.container.skin.ContainerVerbsPanelSkin;
+import org.phoenicis.javafx.utils.CollectionBindings;
 import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.ScriptDTO;
 
@@ -45,51 +44,16 @@ public class ContainerVerbsPanel extends ControlBase<ContainerVerbsPanel, Contai
 
     /**
      * Constructor
-     *
-     * @param container The container
-     * @param verbsManager The verbs manager
-     * @param verbs The application containing the verbs
-     * @param lockVerbs A boolean signifying whether all verb buttons should be locked
-     */
-    public ContainerVerbsPanel(ObjectProperty<ContainerDTO> container, ObjectProperty<VerbsManager> verbsManager,
-            ObjectProperty<ApplicationDTO> verbs, BooleanProperty lockVerbs) {
-        super();
-
-        this.container = container;
-        this.verbsManager = verbsManager;
-        this.verbs = verbs;
-        this.lockVerbs = lockVerbs;
-
-        this.verbScripts = createVerbScripts();
-    }
-
-    /**
-     * Constructor
      */
     public ContainerVerbsPanel() {
-        this(new SimpleObjectProperty<>(), new SimpleObjectProperty<>(), new SimpleObjectProperty<>(),
-                new SimpleBooleanProperty());
-    }
+        super();
 
-    /**
-     * Creates an {@link ObservableList} containing all tool {@link ScriptDTO}s contained in <code>engineTools</code>
-     *
-     * @return An {@link ObservableList} containing all tool {@link ScriptDTO}s contained in <code>engineTools</code>
-     */
-    private ObservableList<ScriptDTO> createVerbScripts() {
-        final ObservableList<ScriptDTO> verbScripts = FXCollections.observableArrayList();
+        this.container = new SimpleObjectProperty<>();
+        this.verbsManager = new SimpleObjectProperty<>();
+        this.verbs = new SimpleObjectProperty<>();
+        this.lockVerbs = new SimpleBooleanProperty();
 
-        verbs.addListener((Observable invalidation) -> {
-            final ApplicationDTO verbs = getVerbs();
-
-            if (verbs != null) {
-                verbScripts.setAll(verbs.getScripts());
-            } else {
-                verbScripts.clear();
-            }
-        });
-
-        return verbScripts;
+        this.verbScripts = CollectionBindings.mapToList(verbsProperty(), ApplicationDTO::getScripts);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersSidebarToggleGroup.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersSidebarToggleGroup.java
@@ -6,7 +6,7 @@ import org.phoenicis.javafx.components.container.skin.ContainersSidebarToggleGro
 import org.phoenicis.javafx.components.common.control.SidebarToggleGroupBase;
 
 /**
- * A toggle group component used inside the {@link ContainersSidebar}
+ * A toggle group component used inside the {@link ContainerSidebar}
  */
 public class ContainersSidebarToggleGroup extends
         SidebarToggleGroupBase<ContainerCategoryDTO, ContainersSidebarToggleGroup, ContainersSidebarToggleGroupSkin> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EngineInformationPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EngineInformationPanelSkin.java
@@ -3,9 +3,7 @@ package org.phoenicis.javafx.components.engine.skin;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-import javafx.collections.FXCollections;
+import javafx.beans.binding.StringBinding;
 import javafx.collections.ObservableMap;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -19,6 +17,8 @@ import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.engine.control.EngineInformationPanel;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
+import org.phoenicis.javafx.utils.CollectionBindings;
+import org.phoenicis.javafx.utils.StringBindings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ public class EngineInformationPanelSkin extends SkinBase<EngineInformationPanel,
     /**
      * The engine version of the shown engine
      */
-    private final StringProperty engineVersionName;
+    private final StringBinding engineVersionName;
 
     /**
      * The user data of the shown engine
@@ -51,8 +51,8 @@ public class EngineInformationPanelSkin extends SkinBase<EngineInformationPanel,
     public EngineInformationPanelSkin(EngineInformationPanel control) {
         super(control);
 
-        this.engineVersionName = new SimpleStringProperty();
-        this.engineUserData = FXCollections.observableHashMap();
+        this.engineVersionName = StringBindings.map(getControl().engineDTOProperty(), EngineDTO::getVersion);
+        this.engineUserData = CollectionBindings.mapToMap(getControl().engineDTOProperty(), EngineDTO::getUserData);
     }
 
     /**
@@ -77,11 +77,6 @@ public class EngineInformationPanelSkin extends SkinBase<EngineInformationPanel,
         final VBox container = new VBox(informationContentPane, informationContentSpacer, buttonBox, buttonBoxSpacer);
 
         getChildren().add(container);
-
-        // ensure that the content of the details panel changes when the to be shown engine changes
-        getControl().engineDTOProperty().addListener((Observable invalidation) -> updateEngine());
-        // initialize the content of the details panel correctly
-        updateEngine();
     }
 
     /**
@@ -180,20 +175,6 @@ public class EngineInformationPanelSkin extends SkinBase<EngineInformationPanel,
             path.setWrapText(true);
 
             userDataGrid.addRow(row, userDataLabel, path);
-        }
-    }
-
-    /**
-     * Updates the {@link Engine} and {@link EngineDTO} of this {@link EngineInformationPanelSkin} instance
-     */
-    private void updateEngine() {
-        final EngineDTO engine = getControl().getEngineDTO();
-
-        if (engine != null) {
-            engineVersionName.setValue(engine.getVersion());
-
-            engineUserData.clear();
-            engineUserData.putAll(engine.getUserData());
         }
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/utils/CollectionBindings.java
@@ -5,8 +5,10 @@ import javafx.beans.Observable;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -14,9 +16,9 @@ import java.util.function.Function;
  */
 public class CollectionBindings {
     /**
-     * Maps a {@link ObservableValue<I>} object to a {@link ObservableList<O>} by applying the given converter function
-     * and adding the result to the {@link ObservableList<O>}.
-     * In case the input value is empty, i.e. contains <code>null</code>, the returned {@link ObservableList<O>} is
+     * Maps an {@link ObservableValue<I>} object to an {@link ObservableList} by applying the given converter function
+     * and adding the result to the {@link ObservableList}.
+     * In case the input value is empty, i.e. contains <code>null</code>, the returned {@link ObservableList} is also
      * empty
      *
      * @param property The input value
@@ -43,6 +45,42 @@ public class CollectionBindings {
         property.addListener(listener);
 
         // ensure that the result list is initialised correctly
+        listener.invalidated(property);
+
+        return result;
+    }
+
+    /**
+     * Maps an {@link ObservableValue<I>} object to an {@link ObservableMap} by applying the given converter function
+     * and adding the result to the {@link ObservableMap}.
+     * In case the input value is empty, i.e. contains <code>null</code>, the returned {@link ObservableMap} is also
+     * empty
+     *
+     * @param property The input value
+     * @param converter The converter function
+     * @param <I> The type of the input value
+     * @param <O1> The input type of the result map
+     * @param <O2> The output type of the result map
+     * @return A {@link ObservableMap} containing the converted map
+     */
+    public static <I, O1, O2> ObservableMap<O1, O2> mapToMap(ObservableValue<I> property,
+            Function<I, Map<O1, O2>> converter) {
+        final ObservableMap<O1, O2> result = FXCollections.observableHashMap();
+
+        final InvalidationListener listener = (Observable invalidation) -> {
+            final I input = property.getValue();
+
+            result.clear();
+
+            if (input != null) {
+                result.putAll(converter.apply(input));
+            }
+        };
+
+        // add the listener to the property
+        property.addListener(listener);
+
+        // ensure that the result map is initialised correctly
         listener.invalidated(property);
 
         return result;


### PR DESCRIPTION
This PR:
- adds a `mapToMap` function to the `CollectionBindings` class
- replaces custom methods with `mapToMap` calls
- replaces custom methods with `mapToList` calls
- removes some unnecessary constructors