### PR TITLE
Add ListConfirmDialog class

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/setting/skin/RepositoriesPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/setting/skin/RepositoriesPanelSkin.java
@@ -21,7 +21,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import org.phoenicis.javafx.components.common.skin.SkinBase;
 import org.phoenicis.javafx.components.setting.control.RepositoriesPanel;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.javafx.views.mainwindow.settings.addrepository.AddRepositoryDialog;
 import org.phoenicis.repository.location.RepositoryLocation;
 import org.phoenicis.repository.types.Repository;
@@ -239,7 +239,7 @@ public class RepositoriesPanelSkin extends SkinBase<RepositoriesPanel, Repositor
         final Button restoreDefault = new Button(tr("Restore defaults"));
         restoreDefault.getStyleClass().add("repositories-restore");
         restoreDefault.setOnAction(event -> {
-            final ConfirmDialog dialog = ConfirmDialog.builder()
+            final SimpleConfirmDialog dialog = SimpleConfirmDialog.builder()
                     .withTitle(tr("Restore default repositories"))
                     .withMessage(tr("Are you sure you want to restore the default repositories?"))
                     .withYesCallback(() -> Platform.runLater(() -> getControl().getRepositoryLocations().setAll(

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -25,7 +25,7 @@ import org.phoenicis.javafx.controller.engines.EnginesController;
 import org.phoenicis.javafx.controller.installations.InstallationsController;
 import org.phoenicis.javafx.controller.library.LibraryController;
 import org.phoenicis.javafx.controller.settings.SettingsController;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.javafx.settings.JavaFxSettingsManager;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.javafx.views.mainwindow.ui.MainWindow;
@@ -93,7 +93,7 @@ public class MainController {
 
     public void setOnClose(Runnable onClose) {
         this.mainWindow.setOnCloseRequest(event -> {
-            final ConfirmDialog confirmDialog = ConfirmDialog.builder()
+            final SimpleConfirmDialog confirmDialog = SimpleConfirmDialog.builder()
                     .withTitle(this.applicationName)
                     .withMessage(tr("Are you sure you want to close all {0} windows?", this.applicationName))
                     .withOwner(this.mainWindow)

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -26,7 +26,7 @@ import org.phoenicis.engines.EngineSetting;
 import org.phoenicis.engines.EngineSettingsManager;
 import org.phoenicis.engines.EngineToolsManager;
 import org.phoenicis.engines.VerbsManager;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
 import org.phoenicis.javafx.views.mainwindow.containers.ContainersView;
 import org.phoenicis.repository.RepositoryManager;
@@ -116,7 +116,7 @@ public class ContainersController {
         this.containersView.setOnSelectContainer(this.containersView::setContainer);
 
         this.containersView.setOnDeleteContainer(container -> {
-            final ConfirmDialog confirmMessage = ConfirmDialog.builder()
+            final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
                     .withTitle(tr("Delete {0} container", container.getName()))
                     .withMessage(tr("Are you sure you want to delete the {0} container?",
                             container.getName()))

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -25,7 +25,7 @@ import org.phoenicis.engines.EnginesManager;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
 import org.phoenicis.engines.dto.EngineSubCategoryDTO;
 import org.phoenicis.javafx.controller.apps.AppsController;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.javafx.views.mainwindow.engines.EnginesView;
@@ -90,7 +90,7 @@ public class EnginesController {
         });
 
         this.enginesView.setOnInstallEngine(engineDTO -> {
-            final ConfirmDialog confirmMessage = ConfirmDialog.builder()
+            final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
                     .withTitle(tr("Install {0}", engineDTO.getVersion()))
                     .withMessage(tr("Are you sure you want to install {0}?", engineDTO.getVersion()))
                     .withOwner(enginesView.getContent().getScene().getWindow())
@@ -116,7 +116,7 @@ public class EnginesController {
         });
 
         this.enginesView.setOnDeleteEngine(engineDTO -> {
-            final ConfirmDialog confirmMessage = ConfirmDialog.builder()
+            final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
                     .withTitle(tr("Delete {0}", engineDTO.getVersion()))
                     .withMessage(tr("Are you sure you want to delete {0}?", engineDTO.getVersion()))
                     .withOwner(enginesView.getContent().getScene().getWindow())

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ConfirmDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ConfirmDialog.java
@@ -4,16 +4,13 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Label;
-import javafx.scene.layout.Region;
-import javafx.stage.Window;
 
 import java.util.Optional;
 
 /**
- * A confirm dialog with two callbacks
+ * An abstract class for confirm dialogs with two callbacks
  */
-public class ConfirmDialog extends Alert {
+public abstract class ConfirmDialog extends Alert {
     /**
      * Callback for {@link ButtonType#OK} button events
      */
@@ -27,24 +24,17 @@ public class ConfirmDialog extends Alert {
     /**
      * Constructor
      */
-    private ConfirmDialog() {
-        super(AlertType.CONFIRMATION);
+    protected ConfirmDialog() {
+        super(Alert.AlertType.CONFIRMATION);
 
         this.yesCallback = new SimpleObjectProperty<>();
         this.noCallback = new SimpleObjectProperty<>();
+
+        getDialogPane().getStyleClass().add("phoenicis-dialog");
     }
 
     /**
-     * Create a new builder for the confirm dialog
-     *
-     * @return A new builder instance
-     */
-    public static ConfirmDialogBuilder builder() {
-        return new ConfirmDialogBuilder();
-    }
-
-    /**
-     * Displays the {@link ConfirmDialog} and waits for a result.
+     * Displays the {@link SimpleConfirmDialog} and waits for a result.
      * After receiving a result from the dialog call either the yes or no callback
      */
     public void showAndCallback() {
@@ -57,11 +47,11 @@ public class ConfirmDialog extends Alert {
     }
 
     public Runnable getYesCallback() {
-        return yesCallback.get();
+        return this.yesCallback.get();
     }
 
     public ObjectProperty<Runnable> yesCallbackProperty() {
-        return yesCallback;
+        return this.yesCallback;
     }
 
     public void setYesCallback(Runnable yesCallback) {
@@ -69,104 +59,14 @@ public class ConfirmDialog extends Alert {
     }
 
     public Runnable getNoCallback() {
-        return noCallback.get();
+        return this.noCallback.get();
     }
 
     public ObjectProperty<Runnable> noCallbackProperty() {
-        return noCallback;
+        return this.noCallback;
     }
 
     public void setNoCallback(Runnable noCallback) {
         this.noCallback.set(noCallback);
-    }
-
-    /**
-     * A builder class for {@link ConfirmDialog} instances
-     */
-    public static class ConfirmDialogBuilder {
-        /**
-         * The title of the {@link ConfirmDialog}
-         */
-        private String title;
-
-        /**
-         * The message of the {@link ConfirmDialog}
-         */
-        private String message;
-
-        /**
-         * The success callback of the {@link ConfirmDialog}
-         */
-        private Runnable yesCallback;
-
-        /**
-         * The failure callback of the {@link ConfirmDialog}
-         */
-        private Runnable noCallback;
-
-        /**
-         * The owner window of the {@link ConfirmDialog}
-         */
-        private Window owner;
-
-        /**
-         * The resizable status of the {@link ConfirmDialog}
-         */
-        private boolean resizable;
-
-        public ConfirmDialogBuilder withTitle(String title) {
-            this.title = title;
-
-            return this;
-        }
-
-        public ConfirmDialogBuilder withMessage(String message) {
-            this.message = message;
-
-            return this;
-        }
-
-        public ConfirmDialogBuilder withYesCallback(Runnable yesCallback) {
-            this.yesCallback = yesCallback;
-
-            return this;
-        }
-
-        public ConfirmDialogBuilder withNoCallback(Runnable noCallback) {
-            this.noCallback = noCallback;
-
-            return this;
-        }
-
-        public ConfirmDialogBuilder withOwner(Window owner) {
-            this.owner = owner;
-
-            return this;
-        }
-
-        public ConfirmDialogBuilder withResizable(boolean resizable) {
-            this.resizable = resizable;
-
-            return this;
-        }
-
-        public ConfirmDialog build() {
-            final ConfirmDialog dialog = new ConfirmDialog();
-
-            dialog.initOwner(owner);
-            dialog.setTitle(title);
-            dialog.setHeaderText(title);
-            dialog.setContentText(message);
-            dialog.setYesCallback(yesCallback);
-            dialog.setNoCallback(noCallback);
-            dialog.setResizable(resizable);
-
-            dialog.getDialogPane().getChildren().stream()
-                    .filter(node -> node instanceof Label)
-                    .map(node -> (Label) node)
-                    .forEach(label -> label.setMinHeight(Region.USE_PREF_SIZE));
-
-            return dialog;
-        }
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ErrorDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ErrorDialog.java
@@ -1,7 +1,6 @@
 package org.phoenicis.javafx.dialogs;
 
 import javafx.application.Platform;
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.Alert;
@@ -12,8 +11,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.stage.Window;
 import org.apache.commons.lang.exception.ExceptionUtils;
-
-import java.util.Optional;
+import org.phoenicis.javafx.utils.StringBindings;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
@@ -50,8 +48,9 @@ public class ErrorDialog extends Alert {
      * Initializes the components used in the {@link ErrorDialog}
      */
     private void initialise() {
-        contentTextProperty().bind(Bindings.createStringBinding(
-                () -> Optional.ofNullable(getException()).map(Exception::getMessage).orElse(null), exception));
+        getDialogPane().getStyleClass().addAll("phoenicis-dialog", "error-dialog");
+
+        contentTextProperty().bind(StringBindings.map(exceptionProperty(), Exception::getMessage));
 
         getDialogPane().setExpandableContent(createExpandableContent());
 
@@ -77,9 +76,7 @@ public class ErrorDialog extends Alert {
         final TextArea textArea = new TextArea();
         textArea.setEditable(false);
 
-        textArea.textProperty().bind(Bindings.createStringBinding(
-                () -> Optional.ofNullable(getException()).map(ExceptionUtils::getFullStackTrace).orElse(null),
-                exception));
+        textArea.textProperty().bind(StringBindings.map(exceptionProperty(), ExceptionUtils::getFullStackTrace));
 
         VBox.setVgrow(textArea, Priority.ALWAYS);
 
@@ -91,11 +88,11 @@ public class ErrorDialog extends Alert {
     }
 
     public Exception getException() {
-        return exception.get();
+        return this.exception.get();
     }
 
     public ObjectProperty<Exception> exceptionProperty() {
-        return exception;
+        return this.exception;
     }
 
     public void setException(Exception exception) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ListConfirmDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/ListConfirmDialog.java
@@ -1,0 +1,170 @@
+package org.phoenicis.javafx.dialogs;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import javafx.stage.Window;
+
+import java.util.List;
+
+/**
+ * A list confirmation dialog, showing a list with items the user can confirm
+ */
+public class ListConfirmDialog extends ConfirmDialog {
+    /**
+     * A list of items to confirm
+     */
+    private final ObservableList<String> confirmItems;
+
+    /**
+     * Constructor
+     */
+    private ListConfirmDialog() {
+        super();
+
+        this.confirmItems = FXCollections.observableArrayList();
+
+        initialise();
+    }
+
+    /**
+     * Create a new builder for the confirm dialog
+     *
+     * @return A new builder instance
+     */
+    public static ListConfirmDialogBuilder builder() {
+        return new ListConfirmDialogBuilder();
+    }
+
+    /**
+     * Initializes the components used in the {@link ListConfirmDialog}
+     */
+    private void initialise() {
+        getDialogPane().getStyleClass().add("list-confirm-dialog");
+
+        final ListView<String> confirmList = new ListView<>(getConfirmItems());
+        confirmList.getStyleClass().add("confirm-list");
+        confirmList.setEditable(false);
+
+        getDialogPane().setExpandableContent(confirmList);
+
+        // ensure that the dialog resizes correctly when the expanded state changes
+        getDialogPane().expandedProperty().addListener(observable -> Platform.runLater(() -> {
+            getDialogPane().requestLayout();
+
+            final Window window = getDialogPane().getScene().getWindow();
+            window.sizeToScene();
+        }));
+
+        // open the confirm list by default
+        getDialogPane().setExpanded(true);
+
+        getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+    }
+
+    public ObservableList<String> getConfirmItems() {
+        return this.confirmItems;
+    }
+
+    /**
+     * A builder class for {@link ListConfirmDialog} instances
+     */
+    public static class ListConfirmDialogBuilder {
+        /**
+         * The title of the {@link ListConfirmDialog}
+         */
+        private String title;
+
+        /**
+         * The message of the {@link ListConfirmDialog}
+         */
+        private String message;
+
+        /**
+         * A list of the confirm items of the {@link ListConfirmDialog}
+         */
+        private List<String> confirmItems;
+
+        /**
+         * The success callback of the {@link ListConfirmDialog}
+         */
+        private Runnable yesCallback;
+
+        /**
+         * The failure callback of the {@link ListConfirmDialog}
+         */
+        private Runnable noCallback;
+
+        /**
+         * The owner window of the {@link ListConfirmDialog}
+         */
+        private Window owner;
+
+        /**
+         * The resizable status of the {@link ListConfirmDialog}
+         */
+        private boolean resizable = true;
+
+        public ListConfirmDialogBuilder withTitle(String title) {
+            this.title = title;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withMessage(String message) {
+            this.message = message;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withConfirmItems(List<String> confirmItems) {
+            this.confirmItems = confirmItems;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withYesCallback(Runnable yesCallback) {
+            this.yesCallback = yesCallback;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withNoCallback(Runnable noCallback) {
+            this.noCallback = noCallback;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withOwner(Window owner) {
+            this.owner = owner;
+
+            return this;
+        }
+
+        public ListConfirmDialogBuilder withResizable(boolean resizable) {
+            this.resizable = resizable;
+
+            return this;
+        }
+
+        public ListConfirmDialog build() {
+            final ListConfirmDialog dialog = new ListConfirmDialog();
+
+            dialog.initOwner(owner);
+            dialog.setTitle(title);
+            dialog.setHeaderText(title);
+            dialog.setContentText(message);
+            dialog.setYesCallback(yesCallback);
+            dialog.setNoCallback(noCallback);
+            dialog.setResizable(resizable);
+
+            if (confirmItems != null) {
+                dialog.getConfirmItems().setAll(confirmItems);
+            }
+
+            return dialog;
+        }
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/SimpleConfirmDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/dialogs/SimpleConfirmDialog.java
@@ -1,0 +1,121 @@
+package org.phoenicis.javafx.dialogs;
+
+import javafx.scene.layout.Region;
+import javafx.stage.Window;
+
+/**
+ * A simple confirm dialog with two callbacks
+ */
+public class SimpleConfirmDialog extends ConfirmDialog {
+    /**
+     * Constructor
+     */
+    private SimpleConfirmDialog() {
+        super();
+
+        initialise();
+    }
+
+    /**
+     * Create a new builder for the confirm dialog
+     *
+     * @return A new builder instance
+     */
+    public static ConfirmDialogBuilder builder() {
+        return new ConfirmDialogBuilder();
+    }
+
+    /**
+     * Initializes the components used in the {@link ListConfirmDialog}
+     */
+    private void initialise() {
+        getDialogPane().getStyleClass().add("simple-confirm-dialog");
+
+        getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+    }
+
+    /**
+     * A builder class for {@link SimpleConfirmDialog} instances
+     */
+    public static class ConfirmDialogBuilder {
+        /**
+         * The title of the {@link SimpleConfirmDialog}
+         */
+        private String title;
+
+        /**
+         * The message of the {@link SimpleConfirmDialog}
+         */
+        private String message;
+
+        /**
+         * The success callback of the {@link SimpleConfirmDialog}
+         */
+        private Runnable yesCallback;
+
+        /**
+         * The failure callback of the {@link SimpleConfirmDialog}
+         */
+        private Runnable noCallback;
+
+        /**
+         * The owner window of the {@link SimpleConfirmDialog}
+         */
+        private Window owner;
+
+        /**
+         * The resizable status of the {@link SimpleConfirmDialog}
+         */
+        private boolean resizable = true;
+
+        public ConfirmDialogBuilder withTitle(String title) {
+            this.title = title;
+
+            return this;
+        }
+
+        public ConfirmDialogBuilder withMessage(String message) {
+            this.message = message;
+
+            return this;
+        }
+
+        public ConfirmDialogBuilder withYesCallback(Runnable yesCallback) {
+            this.yesCallback = yesCallback;
+
+            return this;
+        }
+
+        public ConfirmDialogBuilder withNoCallback(Runnable noCallback) {
+            this.noCallback = noCallback;
+
+            return this;
+        }
+
+        public ConfirmDialogBuilder withOwner(Window owner) {
+            this.owner = owner;
+
+            return this;
+        }
+
+        public ConfirmDialogBuilder withResizable(boolean resizable) {
+            this.resizable = resizable;
+
+            return this;
+        }
+
+        public SimpleConfirmDialog build() {
+            final SimpleConfirmDialog dialog = new SimpleConfirmDialog();
+
+            dialog.initOwner(owner);
+            dialog.setTitle(title);
+            dialog.setHeaderText(title);
+            dialog.setContentText(message);
+            dialog.setYesCallback(yesCallback);
+            dialog.setNoCallback(noCallback);
+            dialog.setResizable(resizable);
+
+            return dialog;
+        }
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
@@ -48,7 +48,7 @@ import org.phoenicis.javafx.components.library.control.LibrarySidebar;
 import org.phoenicis.javafx.components.library.control.ShortcutCreationPanel;
 import org.phoenicis.javafx.components.library.control.ShortcutEditingPanel;
 import org.phoenicis.javafx.components.library.control.ShortcutInformationPanel;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
 import org.phoenicis.javafx.settings.JavaFxSettingsManager;
 import org.phoenicis.javafx.themes.ThemeManager;
@@ -407,7 +407,7 @@ public class LibraryView extends MainWindowView<LibrarySidebar> {
     private void uninstallShortcut(ShortcutDTO shortcut) {
         final String shortcutName = shortcut.getInfo().getName();
 
-        final ConfirmDialog confirmMessage = ConfirmDialog.builder()
+        final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
                 .withTitle(tr("Uninstall {0}", shortcutName))
                 .withMessage(tr("Are you sure you want to uninstall {0}?", shortcutName))
                 .withOwner(content.getScene().getWindow())

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/UiQuestionFactoryJavaFX.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/UiQuestionFactoryJavaFX.java
@@ -20,7 +20,7 @@ package org.phoenicis.javafx.views.scriptui;
 
 import javafx.application.Platform;
 import org.phoenicis.configuration.security.Safe;
-import org.phoenicis.javafx.dialogs.ConfirmDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
 import org.phoenicis.scripts.ui.UiQuestionFactory;
 
 @Safe
@@ -35,7 +35,7 @@ public class UiQuestionFactoryJavaFX implements UiQuestionFactory {
     @Override
     public void create(String questionText, Runnable yesCallback, Runnable noCallback) {
         Platform.runLater(() -> {
-            final ConfirmDialog confirmMessage = ConfirmDialog.builder()
+            final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
                     .withTitle(wizardTitle)
                     .withMessage(questionText)
                     .withResizable(true)

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
@@ -759,6 +759,22 @@
   }
 }
 
+.phoenicis-dialog {
+  &.simple-confirm-dialog {
+    // nothing yet
+  }
+
+  &.list-confirm-dialog {
+    .confirm-list {
+      -fx-pref-height: 7.5em;
+    }
+  }
+
+  &.error-dialog {
+    // nothing yet
+  }
+}
+
 /*******************************************************/
 /************************ icons ************************/
 /*******************************************************/


### PR DESCRIPTION
This PR:
- renames `ConfirmDialog` to `SimpleConfirmDialog`
- adds a new abstract `ConfirmDialog` class
- adds a `ListConfirmDialog` class
- improves the dialog classes

This PR closes #1822.

Screenshot:
![grafik](https://user-images.githubusercontent.com/18488086/53682796-c0c26780-3cf9-11e9-853a-659a30b51a42.png)