### PR TITLE
Add phoenicis script engine interface

### DIFF
--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
@@ -23,9 +23,6 @@ import org.phoenicis.library.dto.ShortcutDTO;
 import org.phoenicis.scripts.interpreter.InteractiveScriptSession;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 
-import javax.script.Invocable;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -45,9 +42,6 @@ public class ShortcutRunner {
     public void run(ShortcutDTO shortcutDTO, List<String> arguments, Consumer<Exception> errorCallback) {
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        ScriptEngineManager m = new ScriptEngineManager();
-        ScriptEngine engine = m.getEngineByName("graal.js");
-        Invocable inv = (Invocable) engine;
         interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                     final Value shortcutReader = (Value) output;
@@ -62,11 +56,10 @@ public class ShortcutRunner {
 
         interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
-                    /*
-                     * final ScriptObjectMirror shortcutReader = (ScriptObjectMirror) output;
-                     * shortcutReader.callMember("of", shortcutDTO);
-                     * shortcutReader.callMember("stop");
-                     */
+                    final Value shortcutReader = (Value) output;
+
+                    shortcutReader.invokeMember("of", shortcutDTO);
+                    shortcutReader.invokeMember("stop");
                 }, errorCallback), errorCallback);
     }
 

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
@@ -18,6 +18,7 @@
 
 package org.phoenicis.library;
 
+import org.graalvm.polyglot.Value;
 import org.phoenicis.library.dto.ShortcutDTO;
 import org.phoenicis.scripts.interpreter.InteractiveScriptSession;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
@@ -25,8 +26,6 @@ import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -51,15 +50,10 @@ public class ShortcutRunner {
         Invocable inv = (Invocable) engine;
         interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
-                    final Object shortcutReader = (Object) output;
-                    try {
-                        inv.invokeMethod(shortcutReader, "of", shortcutDTO);
-                        inv.invokeMethod(shortcutReader, "run", arguments);
-                    } catch (ScriptException e) {
-                        e.printStackTrace();
-                    } catch (NoSuchMethodException e) {
-                        e.printStackTrace();
-                    }
+                    final Value shortcutReader = (Value) output;
+
+                    shortcutReader.invokeMember("of", shortcutDTO);
+                    shortcutReader.invokeMember("run", arguments);
                 }, errorCallback), errorCallback);
     }
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/JSAScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/JSAScriptEngine.java
@@ -1,17 +1,28 @@
 package org.phoenicis.scripts.engine;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * A {@link PhoenicisScriptEngine} wrapping around a {@link ScriptEngine} object defined by the Java Scripting API
+ */
 public class JSAScriptEngine implements PhoenicisScriptEngine {
     private final ScriptEngine scriptEngine;
     private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
 
-    public JSAScriptEngine(ScriptEngine scriptEngine) {
-        this.scriptEngine = scriptEngine;
+    /**
+     * Constructor
+     *
+     * @param engine The name of the engine
+     */
+    public JSAScriptEngine(String engine) {
+        super();
+
+        this.scriptEngine = new ScriptEngineManager().getEngineByName(engine);
     }
 
     public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/JSAScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/JSAScriptEngine.java
@@ -1,0 +1,66 @@
+package org.phoenicis.scripts.engine;
+
+import javax.script.ScriptEngine;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class JSAScriptEngine implements PhoenicisScriptEngine {
+    private final ScriptEngine scriptEngine;
+    private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
+
+    public JSAScriptEngine(ScriptEngine scriptEngine) {
+        this.scriptEngine = scriptEngine;
+    }
+
+    public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {
+        try {
+            this.scriptEngine.eval(inputStreamReader);
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+        }
+    }
+
+    public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
+        try {
+            this.scriptEngine.eval(script);
+            doneCallback.run();
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+        }
+    }
+
+    public Object evalAndReturn(String line, Consumer<Exception> errorCallback) {
+        try {
+            final Object evaluation = this.scriptEngine.eval(line);
+            if (evaluation == null) {
+                return null;
+            }
+            return evaluation;
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+            return "";
+        }
+    }
+
+    private void handleError(Consumer<Exception> errorCallback, Exception e) {
+        for (Consumer<Exception> errorHandler : errorHandlers) {
+            errorHandler.accept(e);
+        }
+        errorCallback.accept(e);
+    }
+
+    public void put(String name, Object object, Consumer<Exception> errorCallback) {
+        try {
+            this.scriptEngine.put(name, object);
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+        }
+    }
+
+    public void addErrorHandler(Consumer<Exception> errorHandler) {
+        errorHandlers.add(errorHandler);
+    }
+
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PhoenicisScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PhoenicisScriptEngine.java
@@ -18,72 +18,23 @@
 
 package org.phoenicis.scripts.engine;
 
-import javax.script.ScriptEngine;
+import com.google.common.util.concurrent.Runnables;
+
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 
-public class PhoenicisScriptEngine {
-    private final ScriptEngine scriptEngine;
-    private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
+public interface PhoenicisScriptEngine {
+    void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback);
 
-    PhoenicisScriptEngine(ScriptEngine scriptEngine) {
-        this.scriptEngine = scriptEngine;
+    void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback);
+
+    default void eval(String script, Consumer<Exception> errorCallback) {
+        eval(script, Runnables.doNothing(), errorCallback);
     }
 
-    public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {
-        try {
-            this.scriptEngine.eval(inputStreamReader);
-        } catch (Exception e) {
-            handleError(errorCallback, e);
-        }
-    }
+    Object evalAndReturn(String line, Consumer<Exception> errorCallback);
 
-    public void eval(String script, Consumer<Exception> errorCallback) {
-        eval(script, () -> {
-        }, errorCallback);
-    }
+    void put(String name, Object object, Consumer<Exception> errorCallback);
 
-    public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
-        try {
-            this.scriptEngine.eval(script);
-            doneCallback.run();
-        } catch (Exception e) {
-            handleError(errorCallback, e);
-        }
-    }
-
-    Object evalAndReturn(String line, Consumer<Exception> errorCallback) {
-        try {
-            final Object evaluation = this.scriptEngine.eval(line);
-            if (evaluation == null) {
-                return null;
-            }
-            return evaluation;
-        } catch (Exception e) {
-            handleError(errorCallback, e);
-            return "";
-        }
-    }
-
-    private void handleError(Consumer<Exception> errorCallback, Exception e) {
-        for (Consumer<Exception> errorHandler : errorHandlers) {
-            errorHandler.accept(e);
-        }
-        errorCallback.accept(e);
-    }
-
-    public void put(String name, Object object, Consumer<Exception> errorCallback) {
-        try {
-            this.scriptEngine.put(name, object);
-        } catch (Exception e) {
-            handleError(errorCallback, e);
-        }
-    }
-
-    public void addErrorHandler(Consumer<Exception> errorHandler) {
-        errorHandlers.add(errorHandler);
-    }
-
+    void addErrorHandler(Consumer<Exception> errorHandler);
 }

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PhoenicisScriptEngineFactory.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PhoenicisScriptEngineFactory.java
@@ -32,9 +32,8 @@ public class PhoenicisScriptEngineFactory {
         this.engineInjectors = engineInjectors;
     }
 
-    PhoenicisScriptEngine createEngine() {
-        final PhoenicisScriptEngine phoenicisScriptEngine = new PhoenicisScriptEngine(
-                new ScriptEngineManager().getEngineByName(type.toString()));
+    public PhoenicisScriptEngine createEngine() {
+        final PhoenicisScriptEngine phoenicisScriptEngine = type.createScriptEngine();
 
         engineInjectors.forEach(engineInjector -> engineInjector.injectInto(phoenicisScriptEngine));
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
@@ -8,19 +8,22 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class PolyglotScriptEngine implements PhoenicisScriptEngine {
     private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
 
+    private final String language;
+
     private final Context context;
 
-    public PolyglotScriptEngine() {
+    public PolyglotScriptEngine(String language, Map<String, String> options) {
         super();
 
-        this.context = Context.newBuilder("js")
-                .option("js.nashorn-compat", "true")
-                .allowHostAccess(true).build();
+        this.language = language;
+        this.context = Context.newBuilder(language)
+                .options(options).allowHostAccess(true).build();
     }
 
     @Override
@@ -37,7 +40,7 @@ public class PolyglotScriptEngine implements PhoenicisScriptEngine {
     @Override
     public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
         try {
-            context.eval("js", script);
+            this.context.eval(this.language, script);
         } catch (Exception e) {
             handleError(errorCallback, e);
         }
@@ -46,7 +49,7 @@ public class PolyglotScriptEngine implements PhoenicisScriptEngine {
     @Override
     public Object evalAndReturn(String script, Consumer<Exception> errorCallback) {
         try {
-            return context.eval("js", script);
+            return this.context.eval(this.language, script);
         } catch (Exception e) {
             handleError(errorCallback, e);
 
@@ -56,7 +59,7 @@ public class PolyglotScriptEngine implements PhoenicisScriptEngine {
 
     @Override
     public void put(String name, Object object, Consumer<Exception> errorCallback) {
-        context.getBindings("js").putMember(name, object);
+        this.context.getBindings(this.language).putMember(name, object);
     }
 
     @Override
@@ -65,7 +68,7 @@ public class PolyglotScriptEngine implements PhoenicisScriptEngine {
     }
 
     private void handleError(Consumer<Exception> errorCallback, Exception e) {
-        for (Consumer<Exception> errorHandler : errorHandlers) {
+        for (Consumer<Exception> errorHandler : this.errorHandlers) {
             errorHandler.accept(e);
         }
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
@@ -11,16 +11,35 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+/**
+ * A {@link PhoenicisScriptEngine} wrapping around a polyglot {@link Context} object defined by Graal
+ */
 public class PolyglotScriptEngine implements PhoenicisScriptEngine {
-    private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
+    /**
+     * A list of error handlers
+     */
+    private final List<Consumer<Exception>> errorHandlers;
 
+    /**
+     * The scripting language
+     */
     private final String language;
 
+    /**
+     * The context representing the handle to the scripting engine
+     */
     private final Context context;
 
+    /**
+     * Constructor
+     *
+     * @param language The language name
+     * @param options A map of options for the Polyglot context
+     */
     public PolyglotScriptEngine(String language, Map<String, String> options) {
         super();
 
+        this.errorHandlers = new ArrayList<>();
         this.language = language;
         this.context = Context.newBuilder(language)
                 .options(options).allowHostAccess(true).build();

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/PolyglotScriptEngine.java
@@ -1,0 +1,74 @@
+package org.phoenicis.scripts.engine;
+
+import com.google.common.util.concurrent.Runnables;
+import org.apache.commons.io.IOUtils;
+import org.graalvm.polyglot.Context;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class PolyglotScriptEngine implements PhoenicisScriptEngine {
+    private final List<Consumer<Exception>> errorHandlers = new ArrayList<>();
+
+    private final Context context;
+
+    public PolyglotScriptEngine() {
+        super();
+
+        this.context = Context.newBuilder("js")
+                .option("js.nashorn-compat", "true")
+                .allowHostAccess(true).build();
+    }
+
+    @Override
+    public void eval(InputStreamReader inputStreamReader, Consumer<Exception> errorCallback) {
+        try {
+            String script = IOUtils.toString(inputStreamReader);
+
+            eval(script, Runnables.doNothing(), errorCallback);
+        } catch (IOException ioe) {
+            handleError(errorCallback, ioe);
+        }
+    }
+
+    @Override
+    public void eval(String script, Runnable doneCallback, Consumer<Exception> errorCallback) {
+        try {
+            context.eval("js", script);
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+        }
+    }
+
+    @Override
+    public Object evalAndReturn(String script, Consumer<Exception> errorCallback) {
+        try {
+            return context.eval("js", script);
+        } catch (Exception e) {
+            handleError(errorCallback, e);
+
+            return "";
+        }
+    }
+
+    @Override
+    public void put(String name, Object object, Consumer<Exception> errorCallback) {
+        context.getBindings("js").putMember(name, object);
+    }
+
+    @Override
+    public void addErrorHandler(Consumer<Exception> errorHandler) {
+        this.errorHandlers.add(errorHandler);
+    }
+
+    private void handleError(Consumer<Exception> errorCallback, Exception e) {
+        for (Consumer<Exception> errorHandler : errorHandlers) {
+            errorHandler.accept(e);
+        }
+
+        errorCallback.accept(e);
+    }
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -10,7 +10,7 @@ public enum ScriptEngineType {
     NASHORN("nashorn") {
         @Override
         public PhoenicisScriptEngine createScriptEngine() {
-            return new JSAScriptEngine(new ScriptEngineManager().getEngineByName("nashorn"));
+            return new JSAScriptEngine("nashorn");
         }
     },
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -1,10 +1,9 @@
 package org.phoenicis.scripts.engine;
 
-import javax.script.ScriptEngineManager;
 import java.util.Map;
 
 /**
- * type of the script engine
+ * The support script engine types
  */
 public enum ScriptEngineType {
     NASHORN("nashorn") {
@@ -21,12 +20,25 @@ public enum ScriptEngineType {
         }
     };
 
+    /**
+     * The name of the script engine type
+     */
     private final String name;
 
+    /**
+     * Constructor
+     *
+     * @param name The name of the script engine type
+     */
     ScriptEngineType(String name) {
         this.name = name;
     }
 
+    /**
+     * Creates a new instance of the {@link ScriptEngineType}
+     *
+     * @return The new instance of the {@link ScriptEngineType}
+     */
     public abstract PhoenicisScriptEngine createScriptEngine();
 
     @Override

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -1,6 +1,7 @@
 package org.phoenicis.scripts.engine;
 
 import javax.script.ScriptEngineManager;
+import java.util.Map;
 
 /**
  * type of the script engine
@@ -16,7 +17,7 @@ public enum ScriptEngineType {
     GRAAL("graal.js") {
         @Override
         public PhoenicisScriptEngine createScriptEngine() {
-            return new PolyglotScriptEngine();
+            return new PolyglotScriptEngine("js", Map.of("js.nashorn-compat", "true"));
         }
     };
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -3,7 +3,7 @@ package org.phoenicis.scripts.engine;
 import java.util.Map;
 
 /**
- * The support script engine types
+ * The supported script engine types
  */
 public enum ScriptEngineType {
     NASHORN("nashorn") {

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -1,16 +1,32 @@
 package org.phoenicis.scripts.engine;
 
+import javax.script.ScriptEngineManager;
+
 /**
  * type of the script engine
  */
 public enum ScriptEngineType {
-    NASHORN("nashorn"), GRAAL("graal.js");
+    NASHORN("nashorn") {
+        @Override
+        public PhoenicisScriptEngine createScriptEngine() {
+            return new JSAScriptEngine(new ScriptEngineManager().getEngineByName("nashorn"));
+        }
+    },
+
+    GRAAL("graal.js") {
+        @Override
+        public PhoenicisScriptEngine createScriptEngine() {
+            return new PolyglotScriptEngine();
+        }
+    };
 
     private final String name;
 
     ScriptEngineType(String name) {
         this.name = name;
     }
+
+    public abstract PhoenicisScriptEngine createScriptEngine();
 
     @Override
     public String toString() {


### PR DESCRIPTION
This PR:
- makes `PhoenicisScriptEngine` an interface
- adds two specific implementations for `PhoenicisScriptEngine` (one based on the Java Scripting API and another one for Polyglot engines) 