### PR TITLE
Fix the close button in the application details panel

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationsFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/control/ApplicationsFeaturePanel.java
@@ -10,7 +10,6 @@ import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetType;
 import org.phoenicis.javafx.settings.JavaFxSettingsManager;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.javafx.views.mainwindow.apps.ApplicationFilter;
-import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 
@@ -49,11 +48,6 @@ public class ApplicationsFeaturePanel extends FeaturePanel<ApplicationsFeaturePa
     private final ObjectProperty<ScriptInterpreter> scriptInterpreter;
 
     /**
-     * The currently selected application
-     */
-    private final ObjectProperty<ApplicationDTO> selectedApplication;
-
-    /**
      * Constructor
      */
     public ApplicationsFeaturePanel() {
@@ -65,7 +59,6 @@ public class ApplicationsFeaturePanel extends FeaturePanel<ApplicationsFeaturePa
         this.selectedListWidget = new SimpleObjectProperty<>();
         this.categories = FXCollections.observableArrayList();
         this.scriptInterpreter = new SimpleObjectProperty<>();
-        this.selectedApplication = new SimpleObjectProperty<>();
     }
 
     /**
@@ -138,17 +131,5 @@ public class ApplicationsFeaturePanel extends FeaturePanel<ApplicationsFeaturePa
 
     public void setScriptInterpreter(ScriptInterpreter scriptInterpreter) {
         this.scriptInterpreter.set(scriptInterpreter);
-    }
-
-    public ApplicationDTO getSelectedApplication() {
-        return this.selectedApplication.get();
-    }
-
-    public ObjectProperty<ApplicationDTO> selectedApplicationProperty() {
-        return this.selectedApplication;
-    }
-
-    public void setSelectedApplication(ApplicationDTO selectedApplication) {
-        this.selectedApplication.set(selectedApplication);
     }
 }


### PR DESCRIPTION
This PR fixes a bug where a click on the close button in the details panel of the applications tab leads to an exception.