### PR TITLE
Refactor the EnginesView class with MVC in mind

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/control/EnginesFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/control/EnginesFeaturePanel.java
@@ -1,0 +1,228 @@
+package org.phoenicis.javafx.components.engine.control;
+
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
+import org.phoenicis.engines.Engine;
+import org.phoenicis.engines.EnginesManager;
+import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.engines.dto.EngineDTO;
+import org.phoenicis.javafx.components.common.control.FeaturePanel;
+import org.phoenicis.javafx.components.engine.skin.EnginesFeaturePanelSkin;
+import org.phoenicis.javafx.dialogs.ErrorDialog;
+import org.phoenicis.javafx.dialogs.SimpleConfirmDialog;
+import org.phoenicis.javafx.settings.JavaFxSettingsManager;
+import org.phoenicis.javafx.views.mainwindow.engines.EnginesFilter;
+
+import static org.phoenicis.configuration.localisation.Localisation.tr;
+
+public class EnginesFeaturePanel extends FeaturePanel<EnginesFeaturePanel, EnginesFeaturePanelSkin> {
+    private final ObjectProperty<EnginesFilter> filter;
+
+    private final ObjectProperty<JavaFxSettingsManager> javaFxSettingsManager;
+
+    private final StringProperty enginesPath;
+
+    private final ObjectProperty<EnginesManager> enginesManager;
+
+    private final ObservableMap<String, Engine> engines;
+
+    private final ObjectProperty<Engine> engine;
+
+    private final ObservableList<EngineCategoryDTO> engineCategories;
+
+    private final ObjectProperty<EngineDTO> engineDTO;
+
+    public EnginesFeaturePanel() {
+        super();
+
+        this.filter = new SimpleObjectProperty<>();
+        this.javaFxSettingsManager = new SimpleObjectProperty<>();
+        this.enginesPath = new SimpleStringProperty();
+        this.enginesManager = new SimpleObjectProperty<>();
+        this.engines = FXCollections.observableHashMap();
+        this.engine = new SimpleObjectProperty<>();
+        this.engineCategories = FXCollections.observableArrayList();
+        this.engineDTO = new SimpleObjectProperty<>();
+    }
+
+    @Override
+    public EnginesFeaturePanelSkin createSkin() {
+        return new EnginesFeaturePanelSkin(this);
+    }
+
+    public void refreshEngineCategory(final EngineCategoryDTO engineCategory) {
+        // TODO: better way to get engine ID
+        final String engineId = engineCategory.getName().toLowerCase();
+
+        getEnginesManager().fetchAvailableVersions(engineId,
+                versions -> {
+                    final EngineCategoryDTO newEngineCategory = new EngineCategoryDTO.Builder(engineCategory)
+                            .withSubCategories(versions)
+                            .build();
+
+                    Platform.runLater(() -> {
+                        getEngineCategories().remove(engineCategory);
+                        getEngineCategories().add(newEngineCategory);
+                    });
+                },
+                e -> Platform.runLater(() -> {
+                    final ErrorDialog errorDialog = ErrorDialog.builder()
+                            .withMessage(tr("Error"))
+                            .withException(e)
+                            .withOwner(getScene().getWindow())
+                            .build();
+
+                    errorDialog.showAndWait();
+                }));
+    }
+
+    public void installEngine(final EngineDTO engineDTO) {
+        final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
+                .withTitle(tr("Install {0}", engineDTO.getVersion()))
+                .withMessage(tr("Are you sure you want to install {0}?", engineDTO.getVersion()))
+                .withOwner(getScene().getWindow())
+                .withResizable(true)
+                .withYesCallback(() -> getEnginesManager().getEngine(engineDTO.getId(),
+                        engine -> {
+                            engine.install(engineDTO.getSubCategory(), engineDTO.getVersion());
+
+                            // TODO: better way to get engine ID
+                            final String engineId = engineDTO.getId().toLowerCase();
+
+                            final EngineCategoryDTO engineCategory = getEngineCategories().stream()
+                                    .filter(engineCategoryDTO -> engineCategoryDTO.getName().equals(engineId))
+                                    .findFirst().orElseThrow();
+
+                            refreshEngineCategory(engineCategory);
+                        }, e -> Platform.runLater(() -> {
+                            final ErrorDialog errorDialog = ErrorDialog.builder()
+                                    .withMessage(tr("Error"))
+                                    .withException(e)
+                                    .withOwner(getScene().getWindow())
+                                    .build();
+
+                            errorDialog.showAndWait();
+                        })))
+                .build();
+
+        confirmMessage.showAndCallback();
+    }
+
+    public void deleteEngine(final EngineDTO engineDTO) {
+        final SimpleConfirmDialog confirmMessage = SimpleConfirmDialog.builder()
+                .withTitle(tr("Delete {0}", engineDTO.getVersion()))
+                .withMessage(tr("Are you sure you want to delete {0}?", engineDTO.getVersion()))
+                .withOwner(getScene().getWindow())
+                .withResizable(true)
+                .withYesCallback(() -> getEnginesManager().getEngine(engineDTO.getId(),
+                        engine -> {
+                            engine.delete(engineDTO.getSubCategory(), engineDTO.getVersion());
+
+                            // TODO: better way to get engine ID
+                            final String engineId = engineDTO.getId().toLowerCase();
+
+                            final EngineCategoryDTO engineCategory = getEngineCategories().stream()
+                                    .filter(engineCategoryDTO -> engineCategoryDTO.getName().equals(engineId))
+                                    .findFirst().orElseThrow();
+
+                            refreshEngineCategory(engineCategory);
+                        }, e -> Platform.runLater(() -> {
+                            final ErrorDialog errorDialog = ErrorDialog.builder()
+                                    .withMessage(tr("Error"))
+                                    .withException(e)
+                                    .withOwner(getScene().getWindow())
+                                    .build();
+
+                            errorDialog.showAndWait();
+                        })))
+                .build();
+
+        confirmMessage.showAndCallback();
+    }
+
+    public EnginesFilter getFilter() {
+        return filter.get();
+    }
+
+    public ObjectProperty<EnginesFilter> filterProperty() {
+        return filter;
+    }
+
+    public void setFilter(EnginesFilter filter) {
+        this.filter.set(filter);
+    }
+
+    public JavaFxSettingsManager getJavaFxSettingsManager() {
+        return javaFxSettingsManager.get();
+    }
+
+    public ObjectProperty<JavaFxSettingsManager> javaFxSettingsManagerProperty() {
+        return javaFxSettingsManager;
+    }
+
+    public void setJavaFxSettingsManager(JavaFxSettingsManager javaFxSettingsManager) {
+        this.javaFxSettingsManager.set(javaFxSettingsManager);
+    }
+
+    public String getEnginesPath() {
+        return enginesPath.get();
+    }
+
+    public StringProperty enginesPathProperty() {
+        return enginesPath;
+    }
+
+    public void setEnginesPath(String enginesPath) {
+        this.enginesPath.set(enginesPath);
+    }
+
+    public ObservableMap<String, Engine> getEngines() {
+        return engines;
+    }
+
+    public Engine getEngine() {
+        return engine.get();
+    }
+
+    public ObjectProperty<Engine> engineProperty() {
+        return engine;
+    }
+
+    public void setEngine(Engine engine) {
+        this.engine.set(engine);
+    }
+
+    public ObservableList<EngineCategoryDTO> getEngineCategories() {
+        return engineCategories;
+    }
+
+    public EngineDTO getEngineDTO() {
+        return engineDTO.get();
+    }
+
+    public ObjectProperty<EngineDTO> engineDTOProperty() {
+        return engineDTO;
+    }
+
+    public void setEngineDTO(EngineDTO engineDTO) {
+        this.engineDTO.set(engineDTO);
+    }
+
+    public EnginesManager getEnginesManager() {
+        return enginesManager.get();
+    }
+
+    public ObjectProperty<EnginesManager> enginesManagerProperty() {
+        return enginesManager;
+    }
+
+    public void setEnginesManager(EnginesManager enginesManager) {
+        this.enginesManager.set(enginesManager);
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesFeaturePanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesFeaturePanelSkin.java
@@ -1,0 +1,171 @@
+package org.phoenicis.javafx.components.engine.skin;
+
+import javafx.beans.Observable;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectExpression;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.scene.Node;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.javafx.collections.ConcatenatedList;
+import org.phoenicis.javafx.collections.MappedList;
+import org.phoenicis.javafx.components.common.control.DetailsPanel;
+import org.phoenicis.javafx.components.common.control.SidebarBase;
+import org.phoenicis.javafx.components.common.skin.FeaturePanelSkin;
+import org.phoenicis.javafx.components.common.widgets.utils.ListWidgetType;
+import org.phoenicis.javafx.components.engine.control.EngineInformationPanel;
+import org.phoenicis.javafx.components.engine.control.EngineSidebar;
+import org.phoenicis.javafx.components.engine.control.EngineSubCategoryPanel;
+import org.phoenicis.javafx.components.engine.control.EnginesFeaturePanel;
+import org.phoenicis.javafx.settings.JavaFxSettingsManager;
+import org.phoenicis.javafx.utils.StringBindings;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class EnginesFeaturePanelSkin extends FeaturePanelSkin<EnginesFeaturePanel, EnginesFeaturePanelSkin> {
+    private final ObjectProperty<ListWidgetType> selectedListWidget;
+
+    private final ObservableList<Tab> engineSubCategoryTabs;
+
+    /**
+     * Constructor
+     *
+     * @param control The control belonging to the skin
+     */
+    public EnginesFeaturePanelSkin(EnginesFeaturePanel control) {
+        super(control);
+
+        this.selectedListWidget = new SimpleObjectProperty<>();
+        this.engineSubCategoryTabs = createEngineSubCategoryTabs();
+    }
+
+    private ObservableList<Tab> createEngineSubCategoryTabs() {
+        // initialize the engines sub category panels
+        final MappedList<List<EngineSubCategoryPanel>, EngineCategoryDTO> engineSubCategoryPanelGroups =
+                new MappedList<>(getControl().getEngineCategories(), engineCategory ->
+                        engineCategory.getSubCategories().stream().map(engineSubCategory -> {
+                            final EngineSubCategoryPanel engineSubCategoryPanel = new EngineSubCategoryPanel();
+
+                            engineSubCategoryPanel.setEngineCategory(engineCategory);
+                            engineSubCategoryPanel.setEngineSubCategory(engineSubCategory);
+
+                            engineSubCategoryPanel.enginesPathProperty().bind(getControl().enginesPathProperty());
+                            engineSubCategoryPanel.filterProperty().bind(getControl().filterProperty());
+                            engineSubCategoryPanel.engineProperty().bind(Bindings.createObjectBinding(() -> {
+                                final String engineCategoryName = engineCategory.getName().toLowerCase();
+
+                                return getControl().getEngines().get(engineCategoryName);
+                            }, getControl().getEngines()));
+
+                            engineSubCategoryPanel.selectedListWidgetProperty().bind(this.selectedListWidget);
+
+                            engineSubCategoryPanel.setOnEngineSelect((engineDTO, engine) -> {
+                                getControl().setEngineDTO(engineDTO);
+                                getControl().setEngine(engine);
+                            });
+
+                            return engineSubCategoryPanel;
+                        }).collect(Collectors.toList()));
+
+        final ConcatenatedList<EngineSubCategoryPanel> engineSubCategoryPanels = ConcatenatedList
+                .create(engineSubCategoryPanelGroups);
+
+        final FilteredList<EngineSubCategoryPanel> filteredEngineSubCategoryPanels = engineSubCategoryPanels
+                // sort the engine sub category panels alphabetically
+                .sorted(Comparator
+                        .comparing(engineSubCategoryPanel -> engineSubCategoryPanel.getEngineSubCategory().getName()))
+                // filter the engine sub category panels, so that only the visible panels remain
+                .filtered(getControl().getFilter()::filter);
+
+        filteredEngineSubCategoryPanels.predicateProperty().bind(
+                Bindings.createObjectBinding(() -> getControl().getFilter()::filter,
+                        getControl().getFilter().searchTermProperty(),
+                        getControl().getFilter().showInstalledProperty(),
+                        getControl().getFilter().showNotInstalledProperty()));
+
+        // map the panels to tabs
+        return new MappedList<>(filteredEngineSubCategoryPanels,
+                engineSubCategoryPanel -> new Tab(engineSubCategoryPanel.getEngineSubCategory().getDescription(),
+                        engineSubCategoryPanel));
+    }
+
+    @Override
+    public ObjectExpression<SidebarBase<?, ?, ?>> createSidebar() {
+        final EngineSidebar sidebar = new EngineSidebar(getControl().getFilter(), getControl().getEngineCategories(), this.selectedListWidget);
+
+        sidebar.javaFxSettingsManagerProperty().bind(getControl().javaFxSettingsManagerProperty());
+
+        // set the default selection
+        sidebar.setSelectedListWidget(Optional
+                .ofNullable(getControl().getJavaFxSettingsManager())
+                .map(JavaFxSettingsManager::getEnginesListType)
+                .orElse(ListWidgetType.ICONS_LIST));
+
+        // save changes to the list widget selection to the hard drive
+        sidebar.selectedListWidgetProperty().addListener((observable, oldValue, newValue) -> {
+            final JavaFxSettingsManager javaFxSettingsManager = getControl().getJavaFxSettingsManager();
+
+            if (newValue != null) {
+                javaFxSettingsManager.setEnginesListType(newValue);
+                javaFxSettingsManager.save();
+            }
+        });
+
+        sidebar.selectedEngineCategoryProperty().addListener((Observable invalidation) -> {
+            final EngineCategoryDTO engineCategory = sidebar.getSelectedEngineCategory();
+
+            if (engineCategory != null) {
+                getControl().refreshEngineCategory(engineCategory);
+            }
+        });
+
+        return new SimpleObjectProperty<>(sidebar);
+    }
+
+    @Override
+    public ObjectExpression<Node> createContent() {
+        final TabPane availableEngines = new TabPane();
+
+        availableEngines.getStyleClass().add("rightPane");
+        availableEngines.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+
+        Bindings.bindContent(availableEngines.getTabs(), this.engineSubCategoryTabs);
+
+        return new SimpleObjectProperty<>(availableEngines);
+    }
+
+    @Override
+    public ObjectExpression<DetailsPanel> createDetailsPanel() {
+        final EngineInformationPanel engineInformationPanel = new EngineInformationPanel();
+
+        engineInformationPanel.engineDTOProperty().bind(getControl().engineDTOProperty());
+        engineInformationPanel.engineProperty().bind(getControl().engineProperty());
+
+        engineInformationPanel.setOnEngineInstall(getControl()::installEngine);
+        engineInformationPanel.setOnEngineDelete(getControl()::deleteEngine);
+
+        final DetailsPanel detailsPanel = new DetailsPanel();
+
+        detailsPanel.titleProperty().bind(StringBindings
+                .map(getControl().engineDTOProperty(), engine -> engine.getCategory() + " " + engine.getSubCategory()));
+        detailsPanel.setContent(engineInformationPanel);
+
+        detailsPanel.setOnClose(() -> {
+            // TODO: deselect the selected engine inside the list widget
+            getControl().setEngine(null);
+            getControl().setEngineDTO(null);
+        });
+
+        detailsPanel.prefWidthProperty().bind(getControl().widthProperty().divide(3));
+
+        return Bindings.when(Bindings.and(Bindings.isNotNull(getControl().engineProperty()), Bindings.isNotNull(getControl().engineDTOProperty())))
+                .then(detailsPanel).otherwise(new SimpleObjectProperty<>());
+    }
+}


### PR DESCRIPTION
This PR refactors the `EnginesView` class with MVC in mind. For this the `EnginesView` class is split into an `EnginesFeaturePanel` and `EnginesFeaturePanelSkin` class.

This PR is still work in progress!