### PR TITLE
Fix missing category icons

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
@@ -44,7 +44,7 @@ public class ApplicationSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(CategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%sButton", category.getId().toLowerCase()));
+        categoryButton.setId(String.format("%s-button", category.getId().toLowerCase().replace('.', '-')));
         categoryButton.setOnAction(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
@@ -31,7 +31,7 @@ public class ApplicationSidebarToggleGroupSkin extends
     protected Optional<ToggleButton> createAllButton() {
         final ToggleButton allCategoryButton = createSidebarToggleButton(tr("All"));
 
-        allCategoryButton.setId("allButton");
+        allCategoryButton.setId("all-button");
         allCategoryButton.setOnAction(event -> getControl().setNothingSelected());
 
         return Optional.of(allCategoryButton);
@@ -44,7 +44,7 @@ public class ApplicationSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(CategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%s-button", category.getId().toLowerCase().replace('.', '-')));
+        categoryButton.setId(SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()));
         categoryButton.setOnAction(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/skin/SidebarToggleGroupBaseSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/common/skin/SidebarToggleGroupBaseSkin.java
@@ -114,4 +114,14 @@ public abstract class SidebarToggleGroupBaseSkin<E, C extends SidebarToggleGroup
     public ToggleGroup getToggleGroup() {
         return toggleGroup;
     }
+
+    /**
+     * Creates a button ID which can be used e.g. to assign icons via CSS based on the category ID
+     *
+     * @param categoryId The category ID which should be used
+     * @return The created button ID
+     */
+    public static String getToggleButtonId(String categoryId) {
+        return String.format("%s-button", categoryId.toLowerCase().replace('.', '-'));
+    }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesSidebarToggleGroupSkin.java
@@ -36,7 +36,7 @@ public class EnginesSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(EngineCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%sButton", category.getName().toLowerCase()));
+        categoryButton.setId(String.format("%s-button", category.getName().toLowerCase().replace('.', '-')));
         categoryButton.setOnAction(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/engine/skin/EnginesSidebarToggleGroupSkin.java
@@ -8,7 +8,7 @@ import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import java.util.Optional;
 
 /**
- * A {@link SidebarToggleGroupBaseSkin} implementation class used inside the {@link EnginesSidebar}
+ * A {@link SidebarToggleGroupBaseSkin} implementation class used inside the {@link EngineSidebar}
  */
 public class EnginesSidebarToggleGroupSkin extends
         SidebarToggleGroupBaseSkin<EngineCategoryDTO, EnginesSidebarToggleGroup, EnginesSidebarToggleGroupSkin> {
@@ -35,8 +35,9 @@ public class EnginesSidebarToggleGroupSkin extends
     @Override
     protected ToggleButton convertToToggleButton(EngineCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
-
-        categoryButton.setId(String.format("%s-button", category.getName().toLowerCase().replace('.', '-')));
+        // TODO: use engine category ID instead of name
+        categoryButton
+                .setId(String.format("engines-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(category.getName())));
         categoryButton.setOnAction(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/installation/skin/InstallationsSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/installation/skin/InstallationsSidebarToggleGroupSkin.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 /**
- * A {@link SidebarToggleGroupBaseSkin} implementation class used inside the {@link InstallationsSidebar}
+ * A {@link SidebarToggleGroupBaseSkin} implementation class used inside the {@link InstallationSidebar}
  */
 public class InstallationsSidebarToggleGroupSkin extends
         SidebarToggleGroupBaseSkin<InstallationCategoryDTO, InstallationsSidebarToggleGroup, InstallationsSidebarToggleGroupSkin> {
@@ -30,7 +30,7 @@ public class InstallationsSidebarToggleGroupSkin extends
     protected Optional<ToggleButton> createAllButton() {
         final ToggleButton allCategoryButton = createSidebarToggleButton(tr("All"));
 
-        allCategoryButton.setId("allButton");
+        allCategoryButton.setId("all-button");
         allCategoryButton.setOnMouseClicked(event -> getControl().setNothingSelected());
 
         return Optional.of(allCategoryButton);
@@ -43,7 +43,7 @@ public class InstallationsSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(InstallationCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%s-button", category.getId().toLowerCase().replace('.', '-')));
+        categoryButton.setId(SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/installation/skin/InstallationsSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/installation/skin/InstallationsSidebarToggleGroupSkin.java
@@ -43,7 +43,7 @@ public class InstallationsSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(InstallationCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%sButton", category.getId().toLowerCase()));
+        categoryButton.setId(String.format("%s-button", category.getId().toLowerCase().replace('.', '-')));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
@@ -30,7 +30,7 @@ public class LibrarySidebarToggleGroupSkin extends
     protected Optional<ToggleButton> createAllButton() {
         final ToggleButton allCategoryButton = createSidebarToggleButton(tr("All"));
 
-        allCategoryButton.setId("allButton");
+        allCategoryButton.setId("all-button");
         allCategoryButton.setOnMouseClicked(event -> getControl().setNothingSelected());
 
         return Optional.of(allCategoryButton);
@@ -42,10 +42,9 @@ public class LibrarySidebarToggleGroupSkin extends
     @Override
     protected ToggleButton convertToToggleButton(ShortcutCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
-
-        categoryButton.setId(String.format("applications-%s-button", category.getId().toLowerCase())); // TODO: store
-                                                                                                       // category ID in
-                                                                                                       // shortcut.info?
+        // TODO: store category ID in shortcut.info?
+        categoryButton.setId(
+                String.format("applications-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId())));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
@@ -43,7 +43,9 @@ public class LibrarySidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(ShortcutCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(String.format("%sButton", category.getId().toLowerCase()));
+        categoryButton.setId(String.format("applications-%s-button", category.getId().toLowerCase())); // TODO: store
+                                                                                                       // category ID in
+                                                                                                       // shortcut.info?
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -79,8 +79,10 @@ public class MainController {
         this.themeManager = themeManager;
         this.javaFxSettingsManager = javaFxSettingsManager;
 
+        // set callbacks and ensure that they are really called at least once initially
         repositoryManager.addCallbacks(this::setDefaultCategoryIcons, e -> {
         });
+        repositoryManager.triggerCallbacks();
 
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);
     }
@@ -124,7 +126,7 @@ public class MainController {
                 List<CategoryDTO> categoryDTOS = repositoryDTO.getTypes().get(0).getCategories();
                 StringBuilder cssBuilder = new StringBuilder();
                 for (CategoryDTO category : categoryDTOS) {
-                    cssBuilder.append("#" + category.getId().toLowerCase() + "Button{\n");
+                    cssBuilder.append("#" + category.getId().toLowerCase().replace(".", "-") + "-button{\n");
                     URI categoryIcon = category.getIcon();
                     if (categoryIcon == null) {
                         cssBuilder

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -19,6 +19,7 @@
 package org.phoenicis.javafx.controller;
 
 import javafx.application.Platform;
+import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import org.phoenicis.javafx.components.installation.control.InstallationsFeaturePanel;
 import org.phoenicis.javafx.controller.apps.AppsController;
 import org.phoenicis.javafx.controller.containers.ContainersController;
@@ -126,7 +127,7 @@ public class MainController {
                 List<CategoryDTO> categoryDTOS = repositoryDTO.getTypes().get(0).getCategories();
                 StringBuilder cssBuilder = new StringBuilder();
                 for (CategoryDTO category : categoryDTOS) {
-                    cssBuilder.append("#" + category.getId().toLowerCase().replace(".", "-") + "-button{\n");
+                    cssBuilder.append("#" + SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()) + "{\n");
                     URI categoryIcon = category.getIcon();
                     if (categoryIcon == null) {
                         cssBuilder

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -70,7 +70,7 @@ public class EnginesController {
         this.enginesView.setOnSelectEngineCategory(engineCategoryDTO -> {
             // TODO: better way to get engine ID
             final String engineId = engineCategoryDTO.getName().toLowerCase();
-            // only if not chached
+            // only if not cached
             if (!this.versionsCache.containsKey(engineId)) {
                 this.enginesManager.fetchAvailableVersions(engineId,
                         versions -> {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -566,39 +566,39 @@
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/all.png');
 }
 
-#customButton {
+#applications-custom-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/custom.png');
 }
 
-#developmentButton {
+#applications-development-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/development.png');
 }
 
-#gamesButton {
+#applications-games-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/games.png');
 }
 
-#graphicsButton {
+#applications-graphics-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/graphics.png');
 }
 
-#internetButton {
+#applications-internet-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/internet.png');
 }
 
-#multimediaButton {
+#applications-multimedia-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/multimedia.png');
 }
 
-#officeButton {
+#applications-office-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/office.png');
 }
 
-#otherButton {
+#applications-other-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/other.png');
 }
 
-#scienceButton {
+#applications-science-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/science.png');
 }
 
@@ -616,7 +616,7 @@
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/engines/wine.png');
 }
 
-#wineButton {
+#engines-wine-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/engines/wine.png');
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -562,7 +562,7 @@
 /*******************************************************/
 
 /************************ apps *************************/
-#allButton {
+#all-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/all.png');
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
@@ -807,11 +807,11 @@
 }
 
 /************************ apps *************************/
-#allButton {
+#all-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/all.png');
 }
 
-#otherButton {
+#other-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/other.png');
 }
 
@@ -865,7 +865,7 @@
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/engines/wine.png');
 }
 
-#wineButton {
+#engines-wine-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/engines/wine.png');
 }
 


### PR DESCRIPTION
Use full category ID in kebab-case for category button ID. This avoids potential naming conflicts e.g. between applications and engines (there could be something like `applications.wine` and `engines.wine`).

fixes #1874 