### PR TITLE
Fix package Script for Graal

### DIFF
--- a/phoenicis-dist/src/scripts/phoenicis-create-package.sh
+++ b/phoenicis-dist/src/scripts/phoenicis-create-package.sh
@@ -35,7 +35,8 @@ PHOENICIS_TARGET="$SCRIPT_PATH/../../target"
 PHOENICIS_JPACKAGER="$SCRIPT_PATH/../../target/jpackager"
 PHOENICIS_RESOURCES="$SCRIPT_PATH/../resources"
 PHOENICIS_MODULES="jdk.crypto.ec,java.base,javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls,java.naming,java.sql,java.scripting,jdk.scripting.nashorn"
-PHOENICIS_JPACKAGER_ARGUMENTS=("-i" "$PHOENICIS_TARGET/lib" "--main-jar" "phoenicis-javafx-$VERSION.jar" "-n" "$PHOENICIS_APPTITLE" "--output" "$PHOENICIS_TARGET/packages/" "--add-modules" "$PHOENICIS_MODULES" "-p" "$PHOENICIS_TARGET/lib/" "--version" "$VERSION")
+PHOENICIS_RUNTIME_OPTIONS="--java-options -XX:+UnlockExperimentalVMOptions --java-options -XX:+EnableJVMCI --java-options -classpath $PHOENICIS_TARGET/lib --java-options --upgrade-module-path=$PHOENICIS_TARGET/lib/compiler.jar"
+PHOENICIS_JPACKAGER_ARGUMENTS=("-i" "$PHOENICIS_TARGET/lib" "--main-jar" "phoenicis-javafx-$VERSION.jar" "-n" "$PHOENICIS_APPTITLE" "--output" "$PHOENICIS_TARGET/packages/" "--add-modules" "$PHOENICIS_MODULES" "-p" "$PHOENICIS_TARGET/lib/" "$PHOENICIS_RUNTIME_OPTIONS" "--version" "$VERSION")
 
 
 _download_jpackager() {

--- a/phoenicis-dist/src/scripts/phoenicis-create-package.sh
+++ b/phoenicis-dist/src/scripts/phoenicis-create-package.sh
@@ -36,7 +36,7 @@ PHOENICIS_JPACKAGER="$SCRIPT_PATH/../../target/jpackager"
 PHOENICIS_RESOURCES="$SCRIPT_PATH/../resources"
 PHOENICIS_MODULES="jdk.crypto.ec,java.base,javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls,java.naming,java.sql,java.scripting,jdk.scripting.nashorn"
 PHOENICIS_RUNTIME_OPTIONS="--java-options -XX:+UnlockExperimentalVMOptions --java-options -XX:+EnableJVMCI --java-options -classpath $PHOENICIS_TARGET/lib --java-options --upgrade-module-path=$PHOENICIS_TARGET/lib/compiler.jar"
-PHOENICIS_JPACKAGER_ARGUMENTS=("-i" "$PHOENICIS_TARGET/lib" "--main-jar" "phoenicis-javafx-$VERSION.jar" "-n" "$PHOENICIS_APPTITLE" "--output" "$PHOENICIS_TARGET/packages/" "--add-modules" "$PHOENICIS_MODULES" "-p" "$PHOENICIS_TARGET/lib/" "$PHOENICIS_RUNTIME_OPTIONS" "--version" "$VERSION")
+PHOENICIS_JPACKAGER_ARGUMENTS=("-i" "$PHOENICIS_TARGET/lib" "--main-jar" "phoenicis-javafx-$VERSION.jar" "-n" "$PHOENICIS_APPTITLE" "--output" "$PHOENICIS_TARGET/packages/" "--add-modules" "$PHOENICIS_MODULES" "-p" "$PHOENICIS_TARGET/lib/" "--version" "$VERSION" "$PHOENICIS_RUNTIME_OPTIONS")
 
 
 _download_jpackager() {


### PR DESCRIPTION
This PR tries to fix the packaging script to work with Graal.js.
When executing the script I currently receive the following error message:

```
Illegal argument [--java-options -XX:+UnlockExperimentalVMOptions --java-options -XX:+EnableJVMCI --java-options -classpath /home/marc/git/POL-POM-5/phoenicis-dist/src/scripts/../../target/lib --java-options --upgrade-module-path=/home/marc/git/POL-POM-5/phoenicis-dist/src/scripts/../../target/lib/compiler.jar]
WARNING: argument [linux-bundle-name] is not supported for current configuration.
```

@qparis @plata any ideas?