### PR TITLE
Fix duplicate exports (Phoenicis does not start from IntelliJ IDEA)

### DIFF
--- a/phoenicis-dist/pom.xml
+++ b/phoenicis-dist/pom.xml
@@ -52,7 +52,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <excludeArtifactIds>commons-logging, xml-apis, xmlParserAPIs, xercesImpl</excludeArtifactIds>
+                            <excludeArtifactIds>bcprov-jdk16, bcmail-jdk16, bcpg-jdk16, commons-logging, xml-apis, xmlParserAPIs, xercesImpl</excludeArtifactIds>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fixes error message:
```
Error occurred during initialization of boot layer
java.lang.module.ResolutionException: Module org.bouncycastle.pg contains package org.bouncycastle.openpgp, module bcpg.jdk16 exports package org.bouncycastle.openpgp to org.bouncycastle.pg
```