### PR TITLE
Add winbind and freetype to the .deb

### DIFF
--- a/phoenicis-dist/src/scripts/phoenicis-create-package.sh
+++ b/phoenicis-dist/src/scripts/phoenicis-create-package.sh
@@ -77,7 +77,7 @@ Version: $VERSION
 Section: misc
 Priority: optional
 Architecture: all
-Depends: unzip, wget, xterm | x-terminal-emulator, python, imagemagick, cabextract, icoutils, p7zip-full, curl
+Depends: unzip, wget, xterm | x-terminal-emulator, python, imagemagick, cabextract, icoutils, p7zip-full, curl, winbind, libfreetype6, libfreetype6:i386
 Maintainer: PlayOnLinux Packaging <packages@playonlinux.com>
 Description: This program is a front-end for wine.
  It permits you to install Windows Games and softwares


### PR DESCRIPTION
They are not provided by the runtime due to crash.