### PR TITLE
Change Signature of the "include" Command to return an Object

### DIFF
--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
@@ -1,12 +1,12 @@
 package org.phoenicis.scripts.engine.injectors;
 
+import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
 import org.phoenicis.scripts.interpreter.ScriptException;
 import org.phoenicis.scripts.interpreter.ScriptFetcher;
-import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Injects Include() function into a Script Engine
@@ -22,16 +22,18 @@ public class IncludeInjector implements EngineInjector {
     public void injectInto(PhoenicisScriptEngine phoenicisScriptEngine) {
         final Set<String> includedScripts = new HashSet<>();
 
-        phoenicisScriptEngine.put("include", (Consumer<String>) argument -> {
+        phoenicisScriptEngine.put("include", (Function<String, Object>) argument -> {
             final String script = scriptFetcher.getScript(argument);
             if (script == null) {
                 throwException(new ScriptException(argument + " is not found"));
             }
 
             if (includedScripts.add(argument)) {
-                phoenicisScriptEngine.eval("//# sourceURL=" + argument + "\n" + script,
+                return phoenicisScriptEngine.evalAndReturn("//# sourceURL=" + argument + "\n" + script,
                         this::throwException);
             }
+
+            return null;
         }, this::throwException);
     }
 }


### PR DESCRIPTION
This PR changes the signature of the `include` operation to return an object. In other words it changes:

```java
void include(String scriptId);
```

to:

```java
Object include(String scriptId);
```

The returned value of the `include` command is the result of the last executed command inside the referenced script.