### PR TITLE
Fix a "TypeError" Exception when deleting a Wine Container

### DIFF
--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
@@ -143,7 +143,8 @@ public class GenericContainersManager implements ContainersManager {
                             ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                                 final org.graalvm.polyglot.Value shortcutReader = (org.graalvm.polyglot.Value) output;
                                 shortcutReader.invokeMember("of", shortcut);
-                                final String containerName = shortcutReader.invokeMember("container").as(String.class);
+                                final String containerName = shortcutReader.invokeMember("getContainer")
+                                        .as(String.class);
                                 if (containerName.equals(container.getName())) {
                                     this.shortcutManager.deleteShortcut(shortcut);
                                 }


### PR DESCRIPTION
This PR changes the called method on `ShortcutReader` from `container()` to `getContainer()` during the deletion of a container. The reason for the change is that `container` has been defined as a getter method which needs to be accessed like a member field, which is semantically wrong.

This PR needs to be merged together with https://github.com/PhoenicisOrg/scripts/pull/1042, which also contains additional information.