### PR TITLE
Add Support for automatic Object Conversion from Java to JS

### DIFF
--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/ScriptEngineType.java
@@ -20,7 +20,9 @@ public enum ScriptEngineType {
     GRAAL("graal.js") {
         @Override
         public PhoenicisScriptEngine createScriptEngine() {
-            return new PolyglotScriptEngine("js", Map.of("js.nashorn-compat", "true"));
+            return new PolyglotScriptEngine("js",
+                    Map.of("js.nashorn-compat", "true",
+                            "js.experimental-foreign-object-prototype", "true"));
         }
     };
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/implementation/PolyglotScriptEngine.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/implementation/PolyglotScriptEngine.java
@@ -43,7 +43,8 @@ public class PolyglotScriptEngine implements PhoenicisScriptEngine {
         this.language = language;
         this.context = Context.newBuilder(language)
                 .allowExperimentalOptions(true)
-                .options(options).allowHostAccess(true).build();
+                .allowHostAccess(true)
+                .options(options).build();
     }
 
     @Override


### PR DESCRIPTION
This PR adds support for some more automatic conversions from Java types to JS types (for example Java `List` to JS `Array`). See also https://github.com/graalvm/graaljs/issues/88 for more details.

I expect this to allow us to remove almost all `Java.from` operations.