### PR TITLE
Fix JS includes (avoid null return if script already included)

### DIFF
--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
@@ -27,7 +27,7 @@ public class IncludeInjector implements EngineInjector {
             if (!includedScripts.containsKey(argument)) {
                 final String script = scriptFetcher.getScript(argument);
                 if (script == null) {
-                    throwException(new ScriptException(argument + " is not found"));
+                    throwException(new ScriptException("Script '" + argument + "' is not found"));
                 }
 
                 includedScripts.put(argument,

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
@@ -24,12 +24,12 @@ public class IncludeInjector implements EngineInjector {
         final Map<String, Object> includedScripts = new HashMap<>();
 
         phoenicisScriptEngine.put("include", (Function<String, Object>) argument -> {
-            final String script = scriptFetcher.getScript(argument);
-            if (script == null) {
-                throwException(new ScriptException(argument + " is not found"));
-            }
-
             if (!includedScripts.containsKey(argument)) {
+                final String script = scriptFetcher.getScript(argument);
+                if (script == null) {
+                    throwException(new ScriptException(argument + " is not found"));
+                }
+
                 includedScripts.put(argument,
                         phoenicisScriptEngine.evalAndReturn("//# sourceURL=" + argument + "\n" + script,
                                 this::throwException));

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
@@ -4,8 +4,8 @@ import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
 import org.phoenicis.scripts.interpreter.ScriptException;
 import org.phoenicis.scripts.interpreter.ScriptFetcher;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -20,7 +20,8 @@ public class IncludeInjector implements EngineInjector {
 
     @Override
     public void injectInto(PhoenicisScriptEngine phoenicisScriptEngine) {
-        final Set<String> includedScripts = new HashSet<>();
+        // store included scripts (include path -> JS object)
+        final Map<String, Object> includedScripts = new HashMap<>();
 
         phoenicisScriptEngine.put("include", (Function<String, Object>) argument -> {
             final String script = scriptFetcher.getScript(argument);
@@ -28,12 +29,13 @@ public class IncludeInjector implements EngineInjector {
                 throwException(new ScriptException(argument + " is not found"));
             }
 
-            if (includedScripts.add(argument)) {
-                return phoenicisScriptEngine.evalAndReturn("//# sourceURL=" + argument + "\n" + script,
-                        this::throwException);
+            if (!includedScripts.containsKey(argument)) {
+                includedScripts.put(argument,
+                        phoenicisScriptEngine.evalAndReturn("//# sourceURL=" + argument + "\n" + script,
+                                this::throwException));
             }
 
-            return null;
+            return includedScripts.get(argument);
         }, this::throwException);
     }
 }


### PR DESCRIPTION
With the old implementation, the `IncludeInjector` would return `null` if the same path has already been included before.