### PR TITLE
Add a ProcessUtils Class

### DIFF
--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/ToolsConfiguration.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/ToolsConfiguration.java
@@ -27,9 +27,10 @@ import org.phoenicis.tools.config.CompatibleConfigFileFormatFactory;
 import org.phoenicis.tools.files.*;
 import org.phoenicis.tools.http.Downloader;
 import org.phoenicis.tools.lnk.LnkParser;
+import org.phoenicis.tools.processes.ProcessUtils;
 import org.phoenicis.tools.system.ArchitectureFetcher;
-import org.phoenicis.tools.system.ScreenManager;
 import org.phoenicis.tools.system.OperatingSystemFetcher;
+import org.phoenicis.tools.system.ScreenManager;
 import org.phoenicis.tools.system.SystemConfiguration;
 import org.phoenicis.tools.system.opener.AutomaticOpener;
 import org.phoenicis.tools.system.opener.Opener;
@@ -133,6 +134,11 @@ public class ToolsConfiguration {
     @Bean
     public TerminalOpener terminalOpener() {
         return systemConfiguration.terminalOpener();
+    }
+
+    @Bean
+    public ProcessUtils processUtils() {
+        return new ProcessUtils();
     }
 
     @Bean

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcess.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcess.java
@@ -1,0 +1,53 @@
+package org.phoenicis.tools.processes;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+/**
+ * A wrapper class around the Java {@link Process} class allowing for a save access to the underlying process from the scripts
+ */
+public class PhoenicisProcess {
+    /**
+     * The process underneath
+     */
+    private final Process process;
+
+    /**
+     * Constructor
+     *
+     * @param process The wrapped process
+     */
+    public PhoenicisProcess(Process process) {
+        super();
+
+        this.process = process;
+    }
+
+    /**
+     * Waits for the underlying process to terminate
+     *
+     * @return This object
+     * @throws InterruptedException thrown if the process is interrupted
+     */
+    public PhoenicisProcess waitFor() throws InterruptedException {
+        this.process.waitFor();
+
+        return this;
+    }
+
+    /**
+     * Gets the output of the process as a String
+     *
+     * @return The output of the process
+     * @throws IOException thrown if an error during the result fetching occurs
+     */
+    public String getOutput() throws IOException {
+        if (this.process.isAlive()) {
+            throw new IllegalStateException("The process hasn't been terminated yet (hint try \"waitFor()\")");
+        }
+
+        return IOUtils.toString(process.getInputStream(), Charset.defaultCharset());
+    }
+}

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcess.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcess.java
@@ -6,7 +6,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 /**
- * A wrapper class around the Java {@link Process} class allowing for a save access to the underlying process from the scripts
+ * A wrapper class around the Java {@link Process} class allowing for a save access to the underlying process from the
+ * scripts
  */
 public class PhoenicisProcess {
     /**

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcessBuilder.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcessBuilder.java
@@ -29,13 +29,6 @@ public class PhoenicisProcessBuilder {
      */
     private String outputPath;
 
-    /**
-     * Constructor
-     */
-    public PhoenicisProcessBuilder() {
-        super();
-    }
-
     public PhoenicisProcessBuilder withCommand(final List<String> command) {
         this.command = command;
 
@@ -81,8 +74,8 @@ public class PhoenicisProcessBuilder {
             throw new IllegalArgumentException("Base path is either does not exist or is no directory");
         }
 
-        if (this.environment == null) {
-            throw new IllegalArgumentException("Environment can't be null");
+        if (environment == null) {
+            environment = Map.of();
         }
 
         final ProcessBuilder processBuilder = new ProcessBuilder()

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcessBuilder.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/PhoenicisProcessBuilder.java
@@ -1,0 +1,106 @@
+package org.phoenicis.tools.processes;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A process builder to be used from inside the scripts
+ */
+public class PhoenicisProcessBuilder {
+    /**
+     * The command executed by the process
+     */
+    private List<String> command;
+
+    /**
+     * The base path where the process is executed in
+     */
+    private String basePath;
+
+    /**
+     * The environment variables
+     */
+    private Map<String, String> environment;
+
+    /**
+     * An optional path where the output is written to
+     */
+    private String outputPath;
+
+    /**
+     * Constructor
+     */
+    public PhoenicisProcessBuilder() {
+        super();
+    }
+
+    public PhoenicisProcessBuilder withCommand(final List<String> command) {
+        this.command = command;
+
+        return this;
+    }
+
+    public PhoenicisProcessBuilder withBasePath(final String basePath) {
+        this.basePath = basePath;
+
+        return this;
+    }
+
+    public PhoenicisProcessBuilder withEnvironment(final Map<String, String> environment) {
+        this.environment = environment;
+
+        return this;
+    }
+
+    public PhoenicisProcessBuilder withOutputPath(final String outputPath) {
+        this.outputPath = outputPath;
+
+        return this;
+    }
+
+    /**
+     * Starts a new Process with the previously specified values
+     *
+     * @return The newly started process
+     * @throws IOException Thrown if the process couldn't be started
+     */
+    public PhoenicisProcess start() throws IOException {
+        if (this.command == null || this.command.isEmpty()) {
+            throw new IllegalArgumentException("Command can't be null or empty");
+        }
+
+        if (this.basePath == null) {
+            throw new IllegalArgumentException("Base path can't be null");
+        }
+
+        final File directory = new File(this.basePath);
+
+        if (!directory.exists() || !directory.isDirectory()) {
+            throw new IllegalArgumentException("Base path is either does not exist or is no directory");
+        }
+
+        if (this.environment == null) {
+            throw new IllegalArgumentException("Environment can't be null");
+        }
+
+        final ProcessBuilder processBuilder = new ProcessBuilder()
+                .command(this.command)
+                .directory(directory)
+                .inheritIO();
+
+        processBuilder.environment().putAll(this.environment);
+
+        if (this.outputPath != null) {
+            final File output = new File(this.outputPath);
+
+            processBuilder.redirectErrorStream(true);
+            processBuilder.redirectOutput(output);
+        }
+
+        final Process process = processBuilder.start();
+
+        return new PhoenicisProcess(process);
+    }
+}

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/ProcessUtils.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/ProcessUtils.java
@@ -2,60 +2,15 @@ package org.phoenicis.tools.processes;
 
 import org.phoenicis.configuration.security.Safe;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 @Safe
 public class ProcessUtils {
 
     /**
-     * Starts a new system process with the given command
+     * Creates a new {@link PhoenicisProcessBuilder} object
      *
-     * @param command     The command to be executed
-     * @param basePath    The location from where the command is executed
-     * @param environment A map of environemnt variables
-     * @param outputPath  An optional path where the output should be saved
-     * @return The created process
-     * @throws IOException thrown if the process couldn't be started
+     * @return The new PhoenicisProcessBuilder object
      */
-    public PhoenicisProcess startProcess(List<String> command, String basePath, Map<String, String> environment, String outputPath) throws IOException {
-        if (command == null || command.isEmpty()) {
-            throw new IllegalArgumentException("Command can't be null or empty");
-        }
-
-        if (basePath == null) {
-            throw new IllegalArgumentException("Base path can't be null");
-        }
-
-        final File directory = new File(basePath);
-
-        if (!directory.exists() || !directory.isDirectory()) {
-            throw new IllegalArgumentException("Base path is either does not exist or is no directory");
-        }
-
-        if (environment == null) {
-            throw new IllegalArgumentException("Environment can't be null");
-        }
-
-        final ProcessBuilder processBuilder = new ProcessBuilder()
-                .command(command)
-                .directory(directory)
-                .inheritIO();
-
-        processBuilder.environment().putAll(environment);
-
-        if (outputPath != null) {
-            final File output = new File(outputPath);
-
-            processBuilder.redirectErrorStream(true);
-            processBuilder.redirectOutput(output);
-        }
-
-        final Process process = processBuilder.start();
-
-        return new PhoenicisProcess(process);
+    public PhoenicisProcessBuilder newBuilder() {
+        return new PhoenicisProcessBuilder();
     }
-
 }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/ProcessUtils.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/processes/ProcessUtils.java
@@ -1,0 +1,61 @@
+package org.phoenicis.tools.processes;
+
+import org.phoenicis.configuration.security.Safe;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Safe
+public class ProcessUtils {
+
+    /**
+     * Starts a new system process with the given command
+     *
+     * @param command     The command to be executed
+     * @param basePath    The location from where the command is executed
+     * @param environment A map of environemnt variables
+     * @param outputPath  An optional path where the output should be saved
+     * @return The created process
+     * @throws IOException thrown if the process couldn't be started
+     */
+    public PhoenicisProcess startProcess(List<String> command, String basePath, Map<String, String> environment, String outputPath) throws IOException {
+        if (command == null || command.isEmpty()) {
+            throw new IllegalArgumentException("Command can't be null or empty");
+        }
+
+        if (basePath == null) {
+            throw new IllegalArgumentException("Base path can't be null");
+        }
+
+        final File directory = new File(basePath);
+
+        if (!directory.exists() || !directory.isDirectory()) {
+            throw new IllegalArgumentException("Base path is either does not exist or is no directory");
+        }
+
+        if (environment == null) {
+            throw new IllegalArgumentException("Environment can't be null");
+        }
+
+        final ProcessBuilder processBuilder = new ProcessBuilder()
+                .command(command)
+                .directory(directory)
+                .inheritIO();
+
+        processBuilder.environment().putAll(environment);
+
+        if (outputPath != null) {
+            final File output = new File(outputPath);
+
+            processBuilder.redirectErrorStream(true);
+            processBuilder.redirectOutput(output);
+        }
+
+        final Process process = processBuilder.start();
+
+        return new PhoenicisProcess(process);
+    }
+
+}


### PR DESCRIPTION
This PR adds a new `ProcessUtils` class which can be used as a `Bean` from the scripts to start new processes (see also #2015)