### PR TITLE
Add a simple Module System for "include"

### DIFF
--- a/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
+++ b/phoenicis-containers/src/main/java/org/phoenicis/containers/GenericContainersManager.java
@@ -135,7 +135,8 @@ public class GenericContainersManager implements ContainersManager {
                     final InteractiveScriptSession interactiveScriptSession = this.scriptInterpreter
                             .createInteractiveSession();
 
-                    interactiveScriptSession.eval("include(\"engines." + engineId + ".shortcuts.reader\");",
+                    interactiveScriptSession.eval(
+                            "const ShortcutReader = include(\"engines." + engineId + ".shortcuts.reader\");",
                             ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                                 final org.graalvm.polyglot.Value shortcutReader = (org.graalvm.polyglot.Value) output;
                                 shortcutReader.invokeMember("of", shortcut);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
@@ -148,7 +148,8 @@ public class LibraryFeaturePanel extends FeaturePanel<LibraryFeaturePanel, Libra
 
         final InteractiveScriptSession interactiveScriptSession = getScriptInterpreter().createInteractiveSession();
 
-        final String scriptInclude = "include(\"engines." + engineId + ".shortcuts." + engineId + "\");";
+        final String scriptInclude = "const Shortcut = include(\"engines." + engineId + ".shortcuts." + engineId
+                + "\");";
 
         interactiveScriptSession.eval(scriptInclude,
                 ignored -> interactiveScriptSession.eval("new " + engine + "Shortcut()",

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibraryView.java
@@ -345,7 +345,8 @@ public class LibraryView extends MainWindowView<LibrarySidebar> {
 
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        final String scriptInclude = "include(\"engines." + engineId + "\".shortcuts." + engineId + "\");";
+        final String scriptInclude = "const Shortcut = include(\"engines." + engineId + "\".shortcuts." + engineId
+                + "\");";
 
         interactiveScriptSession.eval(scriptInclude,
                 ignored -> interactiveScriptSession.eval("new " + engine + "Shortcut()",

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
@@ -120,7 +120,7 @@ public class ShortcutManager {
     public void uninstallFromShortcut(ShortcutDTO shortcutDTO, Consumer<Exception> errorCallback) {
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
+        interactiveScriptSession.eval("const ShortcutReader = include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                     final Value shortcutReader = (Value) output;
                     shortcutReader.invokeMember("of", shortcutDTO);

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutRunner.java
@@ -42,7 +42,7 @@ public class ShortcutRunner {
     public void run(ShortcutDTO shortcutDTO, List<String> arguments, Consumer<Exception> errorCallback) {
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
+        interactiveScriptSession.eval("const ShortcutReader = include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                     final Value shortcutReader = (Value) output;
 
@@ -54,7 +54,7 @@ public class ShortcutRunner {
     public void stop(ShortcutDTO shortcutDTO, Consumer<Exception> errorCallback) {
         final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        interactiveScriptSession.eval("include(\"engines.wine.shortcuts.reader\");",
+        interactiveScriptSession.eval("const ShortcutReader = include(\"engines.wine.shortcuts.reader\");",
                 ignored -> interactiveScriptSession.eval("new ShortcutReader()", output -> {
                     final Value shortcutReader = (Value) output;
 

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/types/ClasspathRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/types/ClasspathRepositoryTest.java
@@ -73,13 +73,17 @@ public class ClasspathRepositoryTest {
 
     @Test
     public void fetchInstallableApplicationsGraphicsPhotofiltreScriptContent() {
-        assertEquals("include(\"engines.wine.quick_script.online_installer_script\");\n" + "\n"
-                + "new OnlineInstallerScript()\n" + "    .name(\"Photofiltre\")\n"
-                + "    .editor(\"Antonio Da Cruz\")\n" + "    .applicationHomepage(\"http://photofiltre.free.fr\")\n"
+        assertEquals("const OnlineInstallerScript = include(\"engines.wine.quick_script.online_installer_script\");\n"
+                + "\n"
+                + "new OnlineInstallerScript()\n"
+                + "    .name(\"Photofiltre\")\n"
+                + "    .editor(\"Antonio Da Cruz\")\n"
+                + "    .applicationHomepage(\"http://photofiltre.free.fr\")\n"
                 + "    .author(\"Quentin PÂRIS\")\n"
                 + "    .url(\"http://photofiltre.free.fr/utils/pf-setup-fr-652.exe\")\n"
-                + "    .checksum(\"dc965875d698cd3f528423846f837d0dcf39616d\")\n" + "    .category(\"Graphics\")\n"
-                + "    .executable(\"PhotoFiltre.exe\")\n" + "    .go();",
+                + "    .checksum(\"dc965875d698cd3f528423846f837d0dcf39616d\")\n"
+                + "    .category(\"Graphics\")\n"
+                + "    .executable(\"PhotoFiltre.exe\");",
                 repository.fetchInstallableApplications().getTypes().get(0).getCategories().get(1).getApplications()
                         .get(0).getScripts()
                         .get(0).getScript().trim());

--- a/phoenicis-repository/src/test/resources/org/phoenicis/repository/repositoryTest/Applications/Graphics/Photofiltre/Online/script.js
+++ b/phoenicis-repository/src/test/resources/org/phoenicis/repository/repositoryTest/Applications/Graphics/Photofiltre/Online/script.js
@@ -1,4 +1,4 @@
-include("engines.wine.quick_script.online_installer_script");
+const OnlineInstallerScript = include("engines.wine.quick_script.online_installer_script");
 
 new OnlineInstallerScript()
     .name("Photofiltre")
@@ -8,5 +8,4 @@ new OnlineInstallerScript()
     .url("http://photofiltre.free.fr/utils/pf-setup-fr-652.exe")
     .checksum("dc965875d698cd3f528423846f837d0dcf39616d")
     .category("Graphics")
-    .executable("PhotoFiltre.exe")
-    .go();
+    .executable("PhotoFiltre.exe");


### PR DESCRIPTION
This PR adds a simple module system to `include`.

When using this PR every script loaded via `include` needs to export their values explicitly to the calling script. To export a value `x` and `y` you can call the following inside the included script:

```javascript
module.x = <<first value to export>>;
module.y = <<second value to export>>;
```

In case only a single value is exported `module.default` can be used:

```javascript
module.default = <<single export>>;
```

The exported values can then be included as followed:

```javascript
// for a "default" export:
const Value = include(...);
// do something with Value

// for multiple exports:
const {x, y} = include(...);
// do something with x and y
```