### PR TITLE
Improve User Friendliness of the "include" Operation

### DIFF
--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/Verb.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/Verb.java
@@ -1,6 +1,6 @@
 package org.phoenicis.engines;
 
-import org.phoenicis.scripts.interpreter.ScriptException;
+import org.phoenicis.scripts.exceptions.ScriptException;
 
 /**
  * Interface which must be implemented by all Verbs in Javascript

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
@@ -23,7 +23,7 @@ import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.repository.dto.RepositoryDTO;
 import org.phoenicis.repository.dto.TypeDTO;
-import org.phoenicis.scripts.interpreter.ScriptException;
+import org.phoenicis.scripts.exceptions.ScriptException;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 import org.phoenicis.scripts.session.InteractiveScriptSession;
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/EngineInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/EngineInjector.java
@@ -1,6 +1,7 @@
 package org.phoenicis.scripts.engine.injectors;
 
 import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
+import org.phoenicis.scripts.exceptions.ScriptException;
 
 /**
  * Injects some code into a Script Engine
@@ -19,6 +20,6 @@ public interface EngineInjector {
      * @param parentException Parent exception
      */
     default void throwException(Exception parentException) {
-        throw new org.phoenicis.scripts.interpreter.ScriptException(parentException);
+        throw new ScriptException(parentException);
     }
 }

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/engine/injectors/IncludeInjector.java
@@ -2,11 +2,15 @@ package org.phoenicis.scripts.engine.injectors;
 
 import org.graalvm.polyglot.Value;
 import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
-import org.phoenicis.scripts.interpreter.ScriptException;
+import org.phoenicis.scripts.exceptions.CircularIncludeException;
+import org.phoenicis.scripts.exceptions.IncludeException;
+import org.phoenicis.scripts.exceptions.ScriptException;
+import org.phoenicis.scripts.exceptions.ScriptNotFoundException;
 import org.phoenicis.scripts.interpreter.ScriptFetcher;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 import java.util.function.Function;
 
 /**
@@ -21,33 +25,48 @@ public class IncludeInjector implements EngineInjector {
 
     @Override
     public void injectInto(PhoenicisScriptEngine phoenicisScriptEngine) {
+        // store scripts that are currently in progress
+        final Stack<String> includeStack = new Stack<>();
         // store included scripts (include path -> JS object)
         final Map<String, Object> includedScripts = new HashMap<>();
 
         phoenicisScriptEngine.put("include", (Function<String, Object>) argument -> {
+            // prevent circular includes
+            if (includeStack.contains(argument)) {
+                throw new CircularIncludeException(argument, includeStack);
+            }
+
+            includeStack.push(argument);
+
             if (!includedScripts.containsKey(argument)) {
                 final String script = scriptFetcher.getScript(argument);
                 if (script == null) {
-                    throwException(new ScriptException("Script '" + argument + "' is not found"));
+                    throw new ScriptNotFoundException(argument);
                 }
 
-                // wrap the loaded script in a function to prevent it from influencing the main script
-                String extendedString = String.format("(module) => { %s }", script);
-                Value includeFunction = (Value) phoenicisScriptEngine.evalAndReturn(extendedString,
-                        this::throwException);
+                try {
+                    // wrap the loaded script in a function to prevent it from influencing the main script
+                    String extendedString = String.format("(module) => { %s }", script);
+                    Value includeFunction = (Value) phoenicisScriptEngine.evalAndReturn(extendedString,
+                            this::throwException);
 
-                // create an empty JS object
-                Value module = (Value) phoenicisScriptEngine.evalAndReturn("({})", this::throwException);
+                    // create an empty JS object
+                    Value module = (Value) phoenicisScriptEngine.evalAndReturn("({})", this::throwException);
 
-                // execute the included function -> populates "module"
-                includeFunction.execute(module);
+                    // execute the included function -> populates "module"
+                    includeFunction.execute(module);
 
-                if (module.hasMember("default")) {
-                    includedScripts.put(argument, module.getMember("default"));
-                } else {
-                    includedScripts.put(argument, module);
+                    if (module.hasMember("default")) {
+                        includedScripts.put(argument, module.getMember("default"));
+                    } else {
+                        includedScripts.put(argument, module);
+                    }
+                } catch (ScriptException se) {
+                    throw new IncludeException(argument, se);
                 }
             }
+
+            includeStack.pop();
 
             return includedScripts.get(argument);
         }, this::throwException);

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/CircularIncludeException.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/CircularIncludeException.java
@@ -1,0 +1,18 @@
+package org.phoenicis.scripts.exceptions;
+
+import java.util.Stack;
+
+/**
+ * An exception that should be thrown in case a circular include has been detected
+ */
+public class CircularIncludeException extends ScriptException {
+    private static String createMessage(String scriptId, Stack<String> includeStack) {
+        String includeStackString = String.join(" -> ", includeStack);
+
+        return String.format("Circular include of \"%s\" in (%s)", scriptId, includeStackString);
+    }
+
+    public CircularIncludeException(String scriptId, Stack<String> includeStack) {
+        super(createMessage(scriptId, includeStack));
+    }
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/IncludeException.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/IncludeException.java
@@ -1,0 +1,14 @@
+package org.phoenicis.scripts.exceptions;
+
+/**
+ * An exception that should be thrown if a script execution error occurred during the include of another scirpt
+ */
+public class IncludeException extends ScriptException {
+    private static String createMessage(String scriptId) {
+        return String.format("Error while including script: \"%s\"", scriptId);
+    }
+
+    public IncludeException(String scriptId, Exception e) {
+        super(createMessage(scriptId), e);
+    }
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/ScriptException.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/ScriptException.java
@@ -16,8 +16,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package org.phoenicis.scripts.interpreter;
+package org.phoenicis.scripts.exceptions;
 
+/**
+ * A generic script execution exception
+ */
 public class ScriptException extends RuntimeException {
     public ScriptException(Exception e) {
         super(e);

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/ScriptNotFoundException.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/exceptions/ScriptNotFoundException.java
@@ -1,0 +1,14 @@
+package org.phoenicis.scripts.exceptions;
+
+/**
+ * An exception that should be thrown if a script could not be located
+ */
+public class ScriptNotFoundException extends ScriptException {
+    private static String createMessage(String scriptId) {
+        return String.format("Script \"%s\" is not found", scriptId);
+    }
+
+    public ScriptNotFoundException(String scriptId) {
+        super(createMessage(scriptId));
+    }
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/ScriptFetcher.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/ScriptFetcher.java
@@ -20,8 +20,7 @@ package org.phoenicis.scripts.interpreter;
 
 import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.repository.dto.ScriptDTO;
-
-import java.util.List;
+import org.phoenicis.scripts.exceptions.ScriptException;
 
 public class ScriptFetcher {
     private final RepositoryManager repositoryManager;

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ui/Message.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ui/Message.java
@@ -18,7 +18,7 @@
 
 package org.phoenicis.scripts.ui;
 
-import org.phoenicis.scripts.interpreter.ScriptException;
+import org.phoenicis.scripts.exceptions.ScriptException;
 
 import java.util.concurrent.Semaphore;
 

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/wizard/UiSetupWizardImplementation.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/wizard/UiSetupWizardImplementation.java
@@ -19,7 +19,7 @@
 package org.phoenicis.scripts.wizard;
 
 import org.apache.commons.io.IOUtils;
-import org.phoenicis.scripts.interpreter.ScriptException;
+import org.phoenicis.scripts.exceptions.ScriptException;
 import org.phoenicis.scripts.ui.*;
 
 import java.io.File;


### PR DESCRIPTION
This PR:
- adds three new exceptions to the script engine: CircularIncludeException, IncludeException and ScriptNotFoundException
- checks for circular includes (fixes #2048)
- throws a dedicated exception when an include fails (#2056)
- moves the exceptions to a new subpackage

Open issues:
The PR works, but our exception processing seems to be a bit strange. In some cases it seems like only parts of the exceptions are shown to the user. Sometimes the terminal contains a different GUI-based exception instead of the `ScriptException`. In addition it seems like the previous `throwException` wrapped every given exception into an additional `ScriptException` which makes understanding the shown exceptions more difficult.
