### PR TITLE
Sort the Verbs in the ContainerVerbsPanel according to their Names

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
@@ -13,6 +13,8 @@ import org.phoenicis.javafx.utils.CollectionBindings;
 import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.ScriptDTO;
 
+import java.util.Comparator;
+
 /**
  * A component used to install verbs in an existing container
  */
@@ -33,7 +35,7 @@ public class ContainerVerbsPanel extends ControlBase<ContainerVerbsPanel, Contai
     private final ObjectProperty<ApplicationDTO> verbs;
 
     /**
-     * A list of all verbs
+     * A list of all verbs sorted according to their names
      */
     private final ObservableList<ScriptDTO> verbScripts;
 
@@ -53,7 +55,9 @@ public class ContainerVerbsPanel extends ControlBase<ContainerVerbsPanel, Contai
         this.verbs = new SimpleObjectProperty<>();
         this.lockVerbs = new SimpleBooleanProperty();
 
-        this.verbScripts = CollectionBindings.mapToList(verbsProperty(), ApplicationDTO::getScripts);
+        this.verbScripts = CollectionBindings
+                .mapToList(verbsProperty(), ApplicationDTO::getScripts)
+                .sorted(Comparator.comparing(ScriptDTO::getScriptName));
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainerVerbsPanel.java
@@ -5,6 +5,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
 import org.phoenicis.containers.dto.ContainerDTO;
 import org.phoenicis.engines.VerbsManager;
 import org.phoenicis.javafx.components.common.control.ControlBase;
@@ -37,7 +38,7 @@ public class ContainerVerbsPanel extends ControlBase<ContainerVerbsPanel, Contai
     /**
      * A list of all verbs sorted according to their names
      */
-    private final ObservableList<ScriptDTO> verbScripts;
+    private final SortedList<ScriptDTO> verbScripts;
 
     /**
      * A boolean signifying whether all verb buttons should be locked


### PR DESCRIPTION
This PR sorts the verbs in the container verbs panel according to the verb names. This is something that has annoyed me for a long time now!