### PR TITLE
Support remembering previously completed Verb Installations

### DIFF
--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
@@ -127,7 +127,8 @@ public interface Engine {
      * Checks whether a given verb has been registered as being "installed"
      *
      * @param verbId The ID of the verb
+     * @param container The container where the verb has been installed
      * @return True if the verb has been registered as being "installed", false otherwise
      */
-    boolean isVerbRegistered(String verbId);
+    boolean isVerbRegistered(String verbId, String container);
 }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
@@ -115,4 +115,19 @@ public interface Engine {
      * @param wizard setup wizard
      */
     void setWizard(SetupWizard wizard);
+
+    /**
+     * Registers as verb as being "installed"
+     *
+     * @param verbId The ID of the verb
+     */
+    void registerVerb(String verbId);
+
+    /**
+     * Checks whether a given verb has been registered as being "installed"
+     *
+     * @param verbId The ID of the verb
+     * @return True if the verb has been registered as being "installed", false otherwise
+     */
+    boolean isVerbRegistered(String verbId);
 }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/Engine.java
@@ -120,8 +120,9 @@ public interface Engine {
      * Registers as verb as being "installed"
      *
      * @param verbId The ID of the verb
+     * @param container The container where the verb has been installed
      */
-    void registerVerb(String verbId);
+    void registerVerb(String verbId, String container);
 
     /**
      * Checks whether a given verb has been registered as being "installed"

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesConfiguration.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesConfiguration.java
@@ -51,7 +51,8 @@ public class EnginesConfiguration {
 
     @Bean
     public VerbsManager verbsManager() {
-        return new VerbsManager(scriptsConfiguration.scriptInterpreter());
+        return new VerbsManager(scriptsConfiguration.scriptInterpreter(),
+                scriptsConfiguration.graalScriptEngineFactory());
     }
 
     @Bean

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
@@ -136,7 +136,7 @@ public class VerbsManager {
         callback.accept(verbs);
     }
 
-    public boolean isVerbInstalled(String engineId, String verbId) {
+    public boolean isVerbInstalled(String engineId, String verbId, String container) {
         final PhoenicisScriptEngine scriptEngine = scriptEngineFactory.createEngine();
 
         final String include = String.format("include(\"engines.%s.engine.implementation\");", engineId);
@@ -146,6 +146,6 @@ public class VerbsManager {
 
         final Engine engine = engineClass.newInstance().as(Engine.class);
 
-        return engine.isVerbRegistered(verbId);
+        return engine.isVerbRegistered(verbId, container);
     }
 }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/VerbsManager.java
@@ -23,6 +23,8 @@ import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.repository.dto.RepositoryDTO;
 import org.phoenicis.repository.dto.TypeDTO;
+import org.phoenicis.scripts.engine.PhoenicisScriptEngineFactory;
+import org.phoenicis.scripts.engine.implementation.PhoenicisScriptEngine;
 import org.phoenicis.scripts.interpreter.ScriptException;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 import org.phoenicis.scripts.session.InteractiveScriptSession;
@@ -39,13 +41,17 @@ import java.util.function.Consumer;
 public class VerbsManager {
     private final ScriptInterpreter scriptInterpreter;
 
+    private final PhoenicisScriptEngineFactory scriptEngineFactory;
+
     /**
      * Constructor
      *
      * @param scriptInterpreter The underlying script interpreter
+     * @param scriptEngineFactory
      */
-    public VerbsManager(ScriptInterpreter scriptInterpreter) {
+    public VerbsManager(ScriptInterpreter scriptInterpreter, PhoenicisScriptEngineFactory scriptEngineFactory) {
         this.scriptInterpreter = scriptInterpreter;
+        this.scriptEngineFactory = scriptEngineFactory;
     }
 
     /**
@@ -128,5 +134,18 @@ public class VerbsManager {
             }
         }
         callback.accept(verbs);
+    }
+
+    public boolean isVerbInstalled(String engineId, String verbId) {
+        final PhoenicisScriptEngine scriptEngine = scriptEngineFactory.createEngine();
+
+        final String include = String.format("include(\"engines.%s.engine.implementation\");", engineId);
+
+        final Value engineClass = (Value) scriptEngine.evalAndReturn(include, exception -> {
+        });
+
+        final Engine engine = engineClass.newInstance().as(Engine.class);
+
+        return engine.isVerbRegistered(verbId);
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/skin/ContainerVerbsPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/skin/ContainerVerbsPanelSkin.java
@@ -146,18 +146,30 @@ public class ContainerVerbsPanelSkin extends SkinBase<ContainerVerbsPanel, Conta
         verbs.getChildren().clear();
 
         for (ScriptDTO verb : getControl().getVerbScripts()) {
+            final boolean alreadyInstalled = getControl().getVerbsManager().isVerbInstalled(
+                    getControl().getContainer().getEngine(), verb.getId());
+
             final int row = verbs.getRowCount();
 
             final CheckBox verbCheck = new CheckBox();
-            verbCheck.disableProperty().bind(getControl().lockVerbsProperty());
+            if (alreadyInstalled) {
+                verbCheck.setDisable(true);
+            } else {
+                verbCheck.disableProperty().bind(getControl().lockVerbsProperty());
+            }
 
             final Label verbName = new Label(verb.getScriptName());
             // select the associated checkbox if the label has been clicked
             verbName.setOnMouseClicked(event -> verbCheck.fire());
 
-            GridPane.setHgrow(verbName, Priority.ALWAYS);
+            final Label installedLabel = new Label();
+            if (alreadyInstalled) {
+                installedLabel.setText(tr("Already Installed"));
+            }
 
-            verbs.addRow(row, verbCheck, verbName);
+            GridPane.setHgrow(installedLabel, Priority.ALWAYS);
+
+            verbs.addRow(row, verbCheck, verbName, installedLabel);
         }
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/skin/ContainerVerbsPanelSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/skin/ContainerVerbsPanelSkin.java
@@ -145,9 +145,12 @@ public class ContainerVerbsPanelSkin extends SkinBase<ContainerVerbsPanel, Conta
     private void updateVerbs(final GridPane verbs) {
         verbs.getChildren().clear();
 
+        String engineId = getControl().getContainer().getEngine();
+        String container = getControl().getContainer().getName();
+
         for (ScriptDTO verb : getControl().getVerbScripts()) {
-            final boolean alreadyInstalled = getControl().getVerbsManager().isVerbInstalled(
-                    getControl().getContainer().getEngine(), verb.getId());
+            final boolean alreadyInstalled = getControl().getVerbsManager()
+                    .isVerbInstalled(engineId, verb.getId(), container);
 
             final int row = verbs.getRowCount();
 


### PR DESCRIPTION
This PR does the Phoenicis part discussed in #1824.

I'm not sure yet whether we want to add the new methods `registerVerb` and `isVerbRegistered` to the engine class, because they seem somehow unrelated to the engine to me.