### PR TITLE
Fix library category icon handling

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/application/skin/ApplicationSidebarToggleGroupSkin.java
@@ -44,9 +44,19 @@ public class ApplicationSidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(CategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
 
-        categoryButton.setId(SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()));
+        categoryButton.setId(ApplicationSidebarToggleGroupSkin.getToggleButtonId(category.getId()));
         categoryButton.setOnAction(event -> getControl().setSelectedElement(category));
 
         return categoryButton;
+    }
+
+    /**
+     * Creates a button ID which can be used e.g. to assign icons via CSS based on the category ID
+     *
+     * @param categoryId The category ID which should be used
+     * @return The created button ID
+     */
+    public static String getToggleButtonId(String categoryId) {
+        return String.format("applications-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(categoryId));
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
@@ -44,9 +44,13 @@ public class LibrarySidebarToggleGroupSkin extends
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
         // TODO: store category ID in shortcut.info?
         categoryButton.setId(
-                String.format("applications-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId())));
+                String.format("applications-%s", LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId())));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;
+    }
+
+    public static String getToggleButtonId(String categoryId) {
+        return String.format("%s-library-button", categoryId.toLowerCase().replace('.', '-'));
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
@@ -43,10 +43,19 @@ public class LibrarySidebarToggleGroupSkin extends
     protected ToggleButton convertToToggleButton(ShortcutCategoryDTO category) {
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
         // TODO: store category ID in shortcut.info?
-        categoryButton.setId(
-                String.format("library-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId())));
+        categoryButton.setId(LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;
+    }
+
+    /**
+     * Creates a button ID which can be used e.g. to assign icons via CSS based on the category ID
+     *
+     * @param categoryId The category ID which should be used
+     * @return The created button ID
+     */
+    public static String getToggleButtonId(String categoryId) {
+        return String.format("library-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(categoryId));
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/skin/LibrarySidebarToggleGroupSkin.java
@@ -44,13 +44,9 @@ public class LibrarySidebarToggleGroupSkin extends
         final ToggleButton categoryButton = createSidebarToggleButton(category.getName());
         // TODO: store category ID in shortcut.info?
         categoryButton.setId(
-                String.format("applications-%s", LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId())));
+                String.format("library-%s", SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId())));
         categoryButton.setOnMouseClicked(event -> getControl().setSelectedElement(category));
 
         return categoryButton;
-    }
-
-    public static String getToggleButtonId(String categoryId) {
-        return String.format("%s-library-button", categoryId.toLowerCase().replace('.', '-'));
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -71,7 +71,6 @@ public class ControllerConfiguration {
                 containersController(),
                 viewsConfiguration.viewInstallations(),
                 settingsController(),
-                repositoryConfiguration.repositoryManager(),
                 themeConfiguration.themeManager(),
                 javaFxSettingsConfiguration.javaFxSettingsManager());
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -97,8 +97,10 @@ public class ControllerConfiguration {
 
     @Bean
     public LibraryController libraryController() {
-        return new LibraryController(viewsConfiguration.viewLibrary(), libraryConfiguration.libraryManager(),
-                repositoryConfiguration.repositoryManager());
+        return new LibraryController(
+                viewsConfiguration.viewLibrary(),
+                libraryConfiguration.libraryManager(),
+                themeConfiguration.themeManager());
     }
 
     @Bean

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -105,7 +105,10 @@ public class ControllerConfiguration {
 
     @Bean
     public AppsController appsController() {
-        return new AppsController(viewsConfiguration.viewApps(), repositoryConfiguration.repositoryManager());
+        return new AppsController(
+                viewsConfiguration.viewApps(),
+                repositoryConfiguration.repositoryManager(),
+                themeConfiguration.themeManager());
     }
 
     @Bean

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -36,9 +36,7 @@ import org.slf4j.LoggerFactory;
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 public class MainController {
-    private final Logger LOGGER = LoggerFactory.getLogger(MainController.class);
     private final MainWindow mainWindow;
-    private final ThemeManager themeManager;
     private final JavaFxSettingsManager javaFxSettingsManager;
 
     private String applicationName;
@@ -50,7 +48,6 @@ public class MainController {
             ContainersController containersController,
             InstallationsFeaturePanel installationsView,
             SettingsController settingsController,
-            RepositoryManager repositoryManager,
             ThemeManager themeManager,
             JavaFxSettingsManager javaFxSettingsManager) {
         super();
@@ -67,7 +64,6 @@ public class MainController {
                 themeManager,
                 javaFxSettingsManager);
 
-        this.themeManager = themeManager;
         this.javaFxSettingsManager = javaFxSettingsManager;
 
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -80,10 +80,8 @@ public class MainController {
         this.themeManager = themeManager;
         this.javaFxSettingsManager = javaFxSettingsManager;
 
-        // set callbacks and ensure that they are really called at least once initially
         repositoryManager.addCallbacks(this::setDefaultCategoryIcons, e -> {
         });
-        repositoryManager.triggerCallbacks();
 
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -19,7 +19,6 @@
 package org.phoenicis.javafx.controller;
 
 import javafx.application.Platform;
-import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import org.phoenicis.javafx.components.installation.control.InstallationsFeaturePanel;
 import org.phoenicis.javafx.controller.apps.AppsController;
 import org.phoenicis.javafx.controller.containers.ContainersController;
@@ -31,17 +30,8 @@ import org.phoenicis.javafx.settings.JavaFxSettingsManager;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.javafx.views.mainwindow.ui.MainWindow;
 import org.phoenicis.repository.RepositoryManager;
-import org.phoenicis.repository.dto.CategoryDTO;
-import org.phoenicis.repository.dto.RepositoryDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
@@ -80,9 +70,6 @@ public class MainController {
         this.themeManager = themeManager;
         this.javaFxSettingsManager = javaFxSettingsManager;
 
-        repositoryManager.addCallbacks(this::setDefaultCategoryIcons, e -> {
-        });
-
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);
     }
 
@@ -111,40 +98,6 @@ public class MainController {
                     .build();
 
             confirmDialog.showAndCallback();
-        });
-    }
-
-    /**
-     * sets the default category icons from the repository for the sidebar buttons
-     *
-     * @param repositoryDTO repository
-     */
-    private void setDefaultCategoryIcons(RepositoryDTO repositoryDTO) {
-        Platform.runLater(() -> {
-            try {
-                List<CategoryDTO> categoryDTOS = repositoryDTO.getTypes().get(0).getCategories();
-                StringBuilder cssBuilder = new StringBuilder();
-                for (CategoryDTO category : categoryDTOS) {
-                    cssBuilder.append("#" + SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()) + "{\n");
-                    URI categoryIcon = category.getIcon();
-                    if (categoryIcon == null) {
-                        cssBuilder
-                                .append("-fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');\n");
-                    } else {
-                        cssBuilder.append("-fx-background-image: url('" + categoryIcon + "');\n");
-                    }
-                    cssBuilder.append("}\n");
-                }
-                String css = cssBuilder.toString();
-                Path temp = Files.createTempFile("defaultCategoryIcons", ".css").toAbsolutePath();
-                File tempFile = temp.toFile();
-                tempFile.deleteOnExit();
-                Files.write(temp, css.getBytes());
-                String defaultCategoryIconsCss = temp.toUri().toString();
-                this.themeManager.setDefaultCategoryIconsCss(defaultCategoryIconsCss);
-            } catch (IOException e) {
-                LOGGER.warn("Could not set default category icons.", e);
-            }
         });
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
@@ -90,15 +91,14 @@ public class AppsController {
                 for (CategoryDTO category : categories) {
                     cssBuilder.append(
                             "#" + ApplicationSidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
-                    URI categoryIcon = category.getIcon();
-                    if (categoryIcon == null) {
-                        cssBuilder
-                                .append("-fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');\n");
-                    } else {
-                        cssBuilder.append("-fx-background-image: url('" + categoryIcon + "');\n");
-                    }
+                    final String categoryIconPath = Optional.ofNullable(category.getIcon())
+                            .map(categoryIcon -> categoryIcon.toString())
+                            .orElse("/org/phoenicis/javafx/views/common/phoenicis.png");
+
+                    cssBuilder.append(String.format("-fx-background-image: url('%s');\n", categoryIconPath));
                     cssBuilder.append("}\n");
                 }
+
                 String css = cssBuilder.toString();
                 Path temp = Files.createTempFile("defaultCategoryIcons", ".css").toAbsolutePath();
                 File tempFile = temp.toFile();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -20,20 +20,34 @@ package org.phoenicis.javafx.controller.apps;
 
 import javafx.application.Platform;
 import org.phoenicis.javafx.components.application.control.ApplicationsFeaturePanel;
+import org.phoenicis.javafx.components.application.skin.ApplicationSidebarToggleGroupSkin;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
+import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.repository.dto.RepositoryDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 public class AppsController {
+    private final Logger LOGGER = LoggerFactory.getLogger(AppsController.class);
     private final ApplicationsFeaturePanel view;
+    private final ThemeManager themeManager;
 
-    public AppsController(ApplicationsFeaturePanel view, RepositoryManager repositoryManager) {
+    public AppsController(ApplicationsFeaturePanel view,
+            RepositoryManager repositoryManager,
+            ThemeManager themeManager) {
         this.view = view;
+        this.themeManager = themeManager;
 
         repositoryManager.addCallbacks(this::populate, this::showError);
     }
@@ -45,9 +59,8 @@ public class AppsController {
     private void populate(RepositoryDTO repositoryDTO) {
         Platform.runLater(() -> {
             final List<CategoryDTO> categoryDTOS = repositoryDTO.getTypes().get(0).getCategories();
-
+            setDefaultCategoryIcons(categoryDTOS);
             getView().getCategories().setAll(categoryDTOS);
-
             getView().setInitialized(true);
         });
     }
@@ -62,6 +75,40 @@ public class AppsController {
                     .build();
 
             errorDialog.showAndWait();
+        });
+    }
+
+    /**
+     * sets the default category icons from the repository for the sidebar buttons
+     *
+     * @param categories categories in repository
+     */
+    private void setDefaultCategoryIcons(List<CategoryDTO> categories) {
+        Platform.runLater(() -> {
+            try {
+                StringBuilder cssBuilder = new StringBuilder();
+                for (CategoryDTO category : categories) {
+                    cssBuilder.append(
+                            "#" + ApplicationSidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
+                    URI categoryIcon = category.getIcon();
+                    if (categoryIcon == null) {
+                        cssBuilder
+                                .append("-fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');\n");
+                    } else {
+                        cssBuilder.append("-fx-background-image: url('" + categoryIcon + "');\n");
+                    }
+                    cssBuilder.append("}\n");
+                }
+                String css = cssBuilder.toString();
+                Path temp = Files.createTempFile("defaultCategoryIcons", ".css").toAbsolutePath();
+                File tempFile = temp.toFile();
+                tempFile.deleteOnExit();
+                Files.write(temp, css.getBytes());
+                String defaultCategoryIconsCss = temp.toUri().toString();
+                this.themeManager.setDefaultCategoryIconsCss(defaultCategoryIconsCss);
+            } catch (IOException e) {
+                LOGGER.warn("Could not set default category icons.", e);
+            }
         });
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -82,7 +82,7 @@ public class LibraryController {
      * sets the default category icons for the library sidebar buttons
      *
      * We cannot use the default category buttons for this purpose for several reasons:
-     * - It cannot be guaranteed that a the repository which contained the category of a certain app does still exists
+     * - It cannot be guaranteed that the repository which contained the category of a certain app does still exist
      * after the app has been installed (e.g. the repository might have been deleted).
      * - It should not be required to fetch the repository to use the library.
      *

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
@@ -98,13 +99,11 @@ public class LibraryController {
                 StringBuilder cssBuilder = new StringBuilder();
                 for (ShortcutCategoryDTO category : categories) {
                     cssBuilder.append("#" + LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
-                    URI categoryIcon = category.getIcon();
-                    if (categoryIcon == null) {
-                        cssBuilder
-                                .append("-fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');\n");
-                    } else {
-                        cssBuilder.append("-fx-background-image: url('" + categoryIcon + "');\n");
-                    }
+                    final String categoryIconPath = Optional.ofNullable(category.getIcon())
+                            .map(categoryIcon -> categoryIcon.toString())
+                            .orElse("/org/phoenicis/javafx/views/common/phoenicis.png");
+
+                    cssBuilder.append(String.format("-fx-background-image: url('%s');\n", categoryIconPath));
                     cssBuilder.append("}\n");
                 }
                 String css = cssBuilder.toString();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -20,38 +20,48 @@ package org.phoenicis.javafx.controller.library;
 
 import javafx.application.Platform;
 import org.phoenicis.javafx.components.library.control.LibraryFeaturePanel;
+import org.phoenicis.javafx.components.library.skin.LibrarySidebarToggleGroupSkin;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
+import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.library.LibraryManager;
 import org.phoenicis.library.dto.ShortcutCategoryDTO;
-import org.phoenicis.repository.RepositoryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 public class LibraryController {
+    private final Logger LOGGER = LoggerFactory.getLogger(LibraryController.class);
     private final LibraryFeaturePanel libraryView;
     private final LibraryManager libraryManager;
+    private final ThemeManager themeManager;
 
-    public LibraryController(LibraryFeaturePanel libraryView, LibraryManager libraryManager,
-            RepositoryManager repositoryManager) {
+    public LibraryController(LibraryFeaturePanel libraryView,
+            LibraryManager libraryManager,
+            ThemeManager themeManager) {
         super();
 
         this.libraryView = libraryView;
         this.libraryManager = libraryManager;
+        this.themeManager = themeManager;
 
         this.libraryManager.setOnUpdate(this::populate);
-
-        repositoryManager.addCallbacks(repository -> this.populate(), this::showError);
-        repositoryManager.triggerCallbacks();
+        this.libraryManager.refresh();
     }
 
     private void populate() {
         final List<ShortcutCategoryDTO> categories = libraryManager.fetchShortcuts();
+        setDefaultLibraryCategoryIcons(categories);
 
         Platform.runLater(() -> {
             getView().getCategories().setAll(categories);
-
             getView().setInitialized(true);
         });
     }
@@ -65,6 +75,48 @@ public class LibraryController {
                     .build();
 
             errorDialog.showAndWait();
+        });
+    }
+
+    /**
+     * sets the default category icons for the library sidebar buttons
+     *
+     * We cannot use the default category buttons for this purpose for several reasons:
+     * - It cannot be guaranteed that a the repository which contained the category of a certain app does still exists
+     * after the app has been installed (e.g. the repository might have been deleted).
+     * - It should not be required to fetch the repository to use the library.
+     *
+     * Therefore, use the following approach:
+     * - When installing an app, store the icon for its category together with the shortcut (i.e. in the library).
+     * - Use this icon as fallback if the theme does not specify an icon for this category.
+     *
+     * @param categories list of shortcut categories
+     */
+    private void setDefaultLibraryCategoryIcons(List<ShortcutCategoryDTO> categories) {
+        Platform.runLater(() -> {
+            try {
+                StringBuilder cssBuilder = new StringBuilder();
+                for (ShortcutCategoryDTO category : categories) {
+                    cssBuilder.append("#" + LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
+                    URI categoryIcon = category.getIcon();
+                    if (categoryIcon == null) {
+                        cssBuilder
+                                .append("-fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');\n");
+                    } else {
+                        cssBuilder.append("-fx-background-image: url('" + categoryIcon + "');\n");
+                    }
+                    cssBuilder.append("}\n");
+                }
+                String css = cssBuilder.toString();
+                Path temp = Files.createTempFile("defaultLibraryCategoryIcons", ".css").toAbsolutePath();
+                File tempFile = temp.toFile();
+                tempFile.deleteOnExit();
+                Files.write(temp, css.getBytes());
+                String defaultLibraryCategoryIconsCss = temp.toUri().toString();
+                this.themeManager.setDefaultLibraryCategoryIconsCss(defaultLibraryCategoryIconsCss);
+            } catch (IOException e) {
+                LOGGER.warn("Could not set default category icons.", e);
+            }
         });
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -19,8 +19,8 @@
 package org.phoenicis.javafx.controller.library;
 
 import javafx.application.Platform;
-import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import org.phoenicis.javafx.components.library.control.LibraryFeaturePanel;
+import org.phoenicis.javafx.components.library.skin.LibrarySidebarToggleGroupSkin;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.library.LibraryManager;
@@ -97,7 +97,7 @@ public class LibraryController {
             try {
                 StringBuilder cssBuilder = new StringBuilder();
                 for (ShortcutCategoryDTO category : categories) {
-                    cssBuilder.append("#" + SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()) + "{\n");
+                    cssBuilder.append("#" + LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
                     URI categoryIcon = category.getIcon();
                     if (categoryIcon == null) {
                         cssBuilder

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -19,8 +19,8 @@
 package org.phoenicis.javafx.controller.library;
 
 import javafx.application.Platform;
+import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import org.phoenicis.javafx.components.library.control.LibraryFeaturePanel;
-import org.phoenicis.javafx.components.library.skin.LibrarySidebarToggleGroupSkin;
 import org.phoenicis.javafx.dialogs.ErrorDialog;
 import org.phoenicis.javafx.themes.ThemeManager;
 import org.phoenicis.library.LibraryManager;
@@ -97,7 +97,7 @@ public class LibraryController {
             try {
                 StringBuilder cssBuilder = new StringBuilder();
                 for (ShortcutCategoryDTO category : categories) {
-                    cssBuilder.append("#" + LibrarySidebarToggleGroupSkin.getToggleButtonId(category.getId()) + "{\n");
+                    cssBuilder.append("#" + SidebarToggleGroupBaseSkin.getToggleButtonId(category.getId()) + "{\n");
                     URI categoryIcon = category.getIcon();
                     if (categoryIcon == null) {
                         cssBuilder

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/themes/ThemeManager.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/themes/ThemeManager.java
@@ -34,6 +34,11 @@ public class ThemeManager {
     private final ObservableList<String> defaultCategoryIconsStylesheets;
 
     /**
+     * The path to the library category icons stylesheet
+     */
+    private final ObservableList<String> defaultLibraryCategoryIconsStylesheets;
+
+    /**
      * The path to the engine icons stylesheet
      */
     private final ObservableList<String> defaultEngineIconsStylesheets;
@@ -59,6 +64,7 @@ public class ThemeManager {
         this.currentTheme = currentTheme;
 
         this.defaultCategoryIconsStylesheets = FXCollections.observableArrayList();
+        this.defaultLibraryCategoryIconsStylesheets = FXCollections.observableArrayList();
         this.defaultEngineIconsStylesheets = FXCollections.observableArrayList();
 
         // the base stylesheets
@@ -68,8 +74,12 @@ public class ThemeManager {
         final ObservableList<String> currentStylesheets = CollectionBindings
                 .mapToList(currentTheme, this::getNonStandardStylesheets);
 
-        this.stylesheets = ConcatenatedList.create(defaultCategoryIconsStylesheets, defaultEngineIconsStylesheets,
-                baseStylesheets, currentStylesheets);
+        this.stylesheets = ConcatenatedList.create(
+                defaultCategoryIconsStylesheets,
+                defaultLibraryCategoryIconsStylesheets,
+                defaultEngineIconsStylesheets,
+                baseStylesheets,
+                currentStylesheets);
 
         final ObjectBinding<Optional<URI>> currentWebEngineUri = ObjectBindings.map(currentTheme,
                 theme -> theme.getResourceUri("description.css"));
@@ -108,6 +118,15 @@ public class ThemeManager {
      */
     public void setDefaultCategoryIconsCss(String defaultCategoryIconsCss) {
         this.defaultCategoryIconsStylesheets.setAll(defaultCategoryIconsCss);
+    }
+
+    /**
+     * Sets the path of the CSS file containing the default library category icons
+     *
+     * @param defaultLibraryCategoryIconsCss The path of the default library category icons
+     */
+    public void setDefaultLibraryCategoryIconsCss(String defaultLibraryCategoryIconsCss) {
+        this.defaultLibraryCategoryIconsStylesheets.setAll(defaultLibraryCategoryIconsCss);
     }
 
     /**

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -589,44 +589,44 @@
 /************************ icons ************************/
 /*******************************************************/
 
-/************************ apps *************************/
-#all-button, #all-library-button {
+/******************** apps/library *********************/
+#all-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/all.png');
 }
 
-#applications-custom-button, #applications-custom-library-button {
+#applications-custom-button, #library-custom-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/custom.png');
 }
 
-#applications-development-button, #applications-development-library-button {
+#applications-development-button, #library-development-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/development.png');
 }
 
-#applications-games-button, #applications-games-library-button {
+#applications-games-button, #library-games-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/games.png');
 }
 
-#applications-graphics-button, #applications-graphics-library-button {
+#applications-graphics-button, #library-graphics-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/graphics.png');
 }
 
-#applications-internet-button, #applications-internet-library-button {
+#applications-internet-button, #library-internet-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/internet.png');
 }
 
-#applications-multimedia-button, #applications-multimedia-library-button {
+#applications-multimedia-button, #library-multimedia-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/multimedia.png');
 }
 
-#applications-office-button, #applications-office-library-button {
+#applications-office-button, #library-office-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/office.png');
 }
 
-#applications-other-button, #applications-other-library-button {
+#applications-other-button, #library-other-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/other.png');
 }
 
-#applications-science-button, #applications-science-library-button {
+#applications-science-button, #library-science-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/science.png');
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -590,43 +590,43 @@
 /*******************************************************/
 
 /************************ apps *************************/
-#all-button {
+#all-button, #all-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/all.png');
 }
 
-#applications-custom-button {
+#applications-custom-button, #applications-custom-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/custom.png');
 }
 
-#applications-development-button {
+#applications-development-button, #applications-development-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/development.png');
 }
 
-#applications-games-button {
+#applications-games-button, #applications-games-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/games.png');
 }
 
-#applications-graphics-button {
+#applications-graphics-button, #applications-graphics-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/graphics.png');
 }
 
-#applications-internet-button {
+#applications-internet-button, #applications-internet-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/internet.png');
 }
 
-#applications-multimedia-button {
+#applications-multimedia-button, #applications-multimedia-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/multimedia.png');
 }
 
-#applications-office-button {
+#applications-office-button, #applications-office-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/office.png');
 }
 
-#applications-other-button {
+#applications-other-button, #applications-other-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/other.png');
 }
 
-#applications-science-button {
+#applications-science-button, #applications-science-library-button {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/science.png');
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
@@ -813,11 +813,11 @@
 }
 
 /************************ apps *************************/
-#all-button {
+#all-button, #all-library-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/all.png');
 }
 
-#other-button {
+#other-button, #other-library-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/other.png');
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/standard/main.less
@@ -813,11 +813,11 @@
 }
 
 /************************ apps *************************/
-#all-button, #all-library-button {
+#all-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/all.png');
 }
 
-#other-button, #other-library-button {
+#other-button {
   -fx-background-image: url('/org/phoenicis/javafx/themes/standard/icons/mainwindow/apps/other.png');
 }
 

--- a/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
@@ -80,8 +80,12 @@ public class LibraryManager {
         List<ShortcutCategoryDTO> shortcuts = new ArrayList<>();
         for (Map.Entry<String, List<ShortcutDTO>> entry : categoryMap.entrySet()) {
             entry.getValue().sort(ShortcutDTO.nameComparator());
-            ShortcutCategoryDTO category = new ShortcutCategoryDTO.Builder().withId(entry.getKey())
-                    .withName(entry.getKey()).withShortcuts(entry.getValue()).build();
+            ShortcutCategoryDTO category = new ShortcutCategoryDTO.Builder()
+                    .withId(entry.getKey())
+                    .withName(entry.getKey())
+                    .withShortcuts(entry.getValue())
+                    .withIcon(entry.getValue().get(0).getCategoryIcon()) // choose one category icon
+                    .build();
             shortcuts.add(tr(category));
         }
 
@@ -108,6 +112,7 @@ public class LibraryManager {
         final String baseName = FilenameUtils.getBaseName(file.getName());
         final File infoFile = new File(shortcutDirectory, baseName + ".info");
         final File iconFile = new File(shortcutDirectory, baseName + ".icon");
+        final File categoryIconFile = new File(shortcutDirectory, baseName + "Category.icon");
         final File miniatureFile = new File(shortcutDirectory, baseName + ".miniature");
 
         final ShortcutInfoDTO.Builder shortcutInfoDTOBuilder;
@@ -131,6 +136,8 @@ public class LibraryManager {
 
         try {
             final URI icon = iconFile.exists() ? iconFile.toURI() : getClass().getResource("phoenicis.png").toURI();
+            final URI categoryIcon = categoryIconFile.exists() ? categoryIconFile.toURI()
+                    : getClass().getResource("phoenicis.png").toURI();
             final URI miniature = miniatureFile.exists() ? miniatureFile.toURI()
                     : getClass().getResource("defaultMiniature.png").toURI();
 
@@ -139,6 +146,7 @@ public class LibraryManager {
                     .withInfo(shortcutInfoDTO)
                     .withScript(IOUtils.toString(new FileInputStream(file), "UTF-8"))
                     .withIcon(icon)
+                    .withCategoryIcon(categoryIcon)
                     .withMiniature(miniature)
                     .build();
         } catch (URISyntaxException | IOException e) {

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
@@ -66,6 +66,7 @@ public class ShortcutManager {
         final File infoFile = new File(shortcutDirectoryFile, baseName + ".info");
         final File scriptFile = new File(shortcutDirectoryFile, baseName + ".shortcut");
         final File iconFile = new File(shortcutDirectoryFile, baseName + ".icon");
+        final File categoryIconFile = new File(shortcutDirectoryFile, baseName + "Category.icon");
         final File miniatureFile = new File(shortcutDirectoryFile, baseName + ".miniature");
 
         if (!shortcutDirectoryFile.exists()) {
@@ -86,6 +87,16 @@ public class ShortcutManager {
                 }
             } catch (IOException | IllegalArgumentException e) {
                 LOGGER.warn("Error while creating shortcut icon", e);
+            }
+            try {
+                if (shortcutDTO.getCategoryIcon() != null) {
+                    File file = createFileWithFallback(shortcutDTO.getCategoryIcon(), "phoenicis.png");
+                    if (file.exists()) {
+                        FileUtils.copyFile(file, categoryIconFile);
+                    }
+                }
+            } catch (IOException | IllegalArgumentException e) {
+                LOGGER.warn("Error while creating shortcut category icon", e);
             }
             try {
                 if (shortcutDTO.getMiniature() != null) {
@@ -139,6 +150,7 @@ public class ShortcutManager {
         final File infoFile = new File(shortcutDirectory, baseName + ".info");
         final File scriptFile = new File(shortcutDirectory, baseName + ".shortcut");
         final File iconFile = new File(shortcutDirectory, baseName + ".icon");
+        final File categoryIconFile = new File(shortcutDirectory, baseName + "Category.icon");
         final File miniatureFile = new File(shortcutDirectory, baseName + ".miniature");
 
         if (infoFile.exists()) {
@@ -151,6 +163,10 @@ public class ShortcutManager {
 
         if (iconFile.exists()) {
             iconFile.delete();
+        }
+
+        if (categoryIconFile.exists()) {
+            categoryIconFile.delete();
         }
 
         if (miniatureFile.exists()) {
@@ -185,6 +201,24 @@ public class ShortcutManager {
                     shortcutDTO = new ShortcutDTO.Builder(shortcutDTO).withIcon(iconBackup.toURI()).build();
                 } catch (IOException e) {
                     LOGGER.error("Could not backup icon.", e);
+                }
+            }
+        }
+
+        // backup category icon if it didn't change (deleteShortcut will delete it -> icon lost after shortcut update)
+        final File categoryIconFile = new File(shortcutDirectory, baseName + "Category.icon");
+        final File categoryIconBackup = new File(shortcutDirectory, baseName + "Category.icon_backup");
+        final URI shortcutCategoryIcon = shortcutDTO.getCategoryIcon();
+
+        if (shortcutCategoryIcon != null && shortcutCategoryIcon.getPath() != null) {
+            final boolean keepIcon = shortcutCategoryIcon.getPath().equals(categoryIconFile.getPath());
+            if (keepIcon) {
+                try {
+                    Files.move(categoryIconFile.toPath(), categoryIconBackup.toPath());
+                    shortcutDTO = new ShortcutDTO.Builder(shortcutDTO).withCategoryIcon(categoryIconBackup.toURI())
+                            .build();
+                } catch (IOException e) {
+                    LOGGER.error("Could not backup category icon.", e);
                 }
             }
         }

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
@@ -37,13 +37,13 @@ public class ShortcutDTO {
     // it is necessary to store the category icon per shortcut, otherwise category icons in the library could be
     // overwritten if multiple shortcuts from different sources use the same category
     // this could lead to a strange behavior in the following case:
-    // an app A with category c and category icon I(a) from repository R1 is installed
-    // if the theme does not specify an icon, I(a) is shown in the library
-    // an app B with category c and category icon I(b) from repository R2 is installed such that I(a) != I(b) (even
-    // though the category is the same)
-    // if the theme does not specify an icon, I(b) is shown in the library
+    // an app A with category C and category icon I(A) from repository R1 is installed
+    // if the theme does not specify an icon, I(A) is shown in the library
+    // an app B with category C and category icon I(B) from repository R2 is installed such that I(A) != I(B) (even
+    // though the category C is the same)
+    // if the theme does not specify an icon, I(B) is shown in the library
     // app B is uninstalled
-    // if the theme does not specify an icon, I(b) is still shown in the library even though the situation is the same
+    // if the theme does not specify an icon, I(B) is still shown in the library even though the situation is the same
     // as after installing app A
     private final URI categoryIcon;
     private final URI miniature;

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
@@ -34,6 +34,18 @@ public class ShortcutDTO {
     private final String id;
     private final ShortcutInfoDTO info;
     private final URI icon;
+    // it is necessary to store the category icon per shortcut, otherwise category icons in the library could be
+    // overwritten if multiple shortcuts from different sources use the same category
+    // this could lead to a strange behavior in the following case:
+    // an app A with category c and category icon I(a) from repository R1 is installed
+    // if the theme does not specify an icon, I(a) is shown in the library
+    // an app B with category c and category icon I(b) from repository R2 is installed such that I(a) != I(b) (even
+    // though the category is the same)
+    // if the theme does not specify an icon, I(b) is shown in the library
+    // app B is uninstalled
+    // if the theme does not specify an icon, I(b) is still shown in the library even though the situation is the same
+    // as after installing app A
+    private final URI categoryIcon;
     private final URI miniature;
     private final String script;
 
@@ -52,6 +64,7 @@ public class ShortcutDTO {
 
         info = builder.info;
         icon = builder.icon;
+        categoryIcon = builder.categoryIcon;
         miniature = builder.miniature;
         script = builder.script;
     }
@@ -62,6 +75,10 @@ public class ShortcutDTO {
 
     public URI getIcon() {
         return icon;
+    }
+
+    public URI getCategoryIcon() {
+        return categoryIcon;
     }
 
     public URI getMiniature() {
@@ -96,6 +113,7 @@ public class ShortcutDTO {
                 .append(id, that.id)
                 .append(info, that.info)
                 .append(icon, that.icon)
+                .append(categoryIcon, that.categoryIcon)
                 .append(miniature, that.miniature)
                 .append(script, that.script)
                 .isEquals();
@@ -107,6 +125,7 @@ public class ShortcutDTO {
                 .append(id)
                 .append(info)
                 .append(icon)
+                .append(categoryIcon)
                 .append(miniature)
                 .append(script)
                 .toHashCode();
@@ -117,6 +136,7 @@ public class ShortcutDTO {
         private String id;
         private ShortcutInfoDTO info;
         private URI icon;
+        private URI categoryIcon;
         private URI miniature;
         private String script;
 
@@ -128,6 +148,7 @@ public class ShortcutDTO {
             this.info = shortcutDTO.info;
             this.id = shortcutDTO.id;
             this.icon = shortcutDTO.icon;
+            this.categoryIcon = shortcutDTO.categoryIcon;
             this.miniature = shortcutDTO.miniature;
             this.script = shortcutDTO.script;
         }
@@ -144,6 +165,11 @@ public class ShortcutDTO {
 
         public Builder withIcon(URI icon) {
             this.icon = icon;
+            return this;
+        }
+
+        public Builder withCategoryIcon(URI categoryIcon) {
+            this.categoryIcon = categoryIcon;
             return this;
         }
 

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
@@ -34,17 +34,19 @@ public class ShortcutDTO {
     private final String id;
     private final ShortcutInfoDTO info;
     private final URI icon;
-    // it is necessary to store the category icon per shortcut, otherwise category icons in the library could be
-    // overwritten if multiple shortcuts from different sources use the same category
-    // this could lead to a strange behavior in the following case:
-    // an app A with category C and category icon I(A) from repository R1 is installed
-    // if the theme does not specify an icon, I(A) is shown in the library
-    // an app B with category C and category icon I(B) from repository R2 is installed such that I(A) != I(B) (even
-    // though the category C is the same)
-    // if the theme does not specify an icon, I(B) is shown in the library
-    // app B is uninstalled
-    // if the theme does not specify an icon, I(B) is still shown in the library even though the situation is the same
-    // as after installing app A
+    /*
+     * it is necessary to store the category icon per shortcut, otherwise category icons in the library could be
+     * overwritten if multiple shortcuts from different sources use the same category
+     * this could lead to a strange behavior in the following case:
+     * 1. an app A with category C and category icon I(A) from repository R1 is installed
+     * if the theme does not specify an icon, I(A) is shown in the library
+     * 2. an app B with category C and category icon I(B) from repository R2 is installed such that I(A) != I(B) (even
+     * though the category C is the same)
+     * if the theme does not specify an icon, I(B) is shown in the library
+     * 3. app B is uninstalled
+     * if the theme does not specify an icon, I(B) is still shown in the library even though the situation is the same
+     * as after installing app A
+     */
     private final URI categoryIcon;
     private final URI miniature;
     private final String script;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
@@ -1,12 +1,9 @@
 package org.phoenicis.repository;
 
 import org.phoenicis.configuration.security.Safe;
-import org.phoenicis.repository.dto.ApplicationDTO;
-import org.phoenicis.repository.dto.RepositoryDTO;
-import org.phoenicis.repository.dto.ScriptDTO;
+import org.phoenicis.repository.dto.*;
 import org.phoenicis.repository.location.RepositoryLocation;
 import org.phoenicis.repository.types.*;
-import org.phoenicis.tools.files.FileUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +56,16 @@ public class DefaultRepositoryManager implements RepositoryManager {
     @Override
     public synchronized void addCallbacks(Consumer<RepositoryDTO> onRepositoryChange, Consumer<Exception> onError) {
         this.callbacks.add(new CallbackPair(onRepositoryChange, onError));
+    }
+
+    @Override
+    public TypeDTO getType(List<String> path) {
+        return this.cachedRepository.getType(path);
+    }
+
+    @Override
+    public CategoryDTO getCategory(List<String> path) {
+        return this.cachedRepository.getCategory(path);
     }
 
     @Override

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryManager.java
@@ -1,9 +1,7 @@
 package org.phoenicis.repository;
 
-import org.phoenicis.repository.dto.ApplicationDTO;
-import org.phoenicis.repository.dto.RepositoryDTO;
+import org.phoenicis.repository.dto.*;
 import org.phoenicis.repository.location.RepositoryLocation;
-import org.phoenicis.repository.dto.ScriptDTO;
 import org.phoenicis.repository.types.Repository;
 
 import java.util.List;
@@ -24,6 +22,24 @@ public interface RepositoryManager {
      * @param onError The callback that should be called when the repository change failed
      */
     void addCallbacks(Consumer<RepositoryDTO> onRepositoryChange, Consumer<Exception> onError);
+
+    /**
+     * This method returns the {@link org.phoenicis.repository.dto.TypeDTO}, which can be found at the given
+     * path.
+     *
+     * @param path The path, where the searched TypeDTO can be found
+     * @return The found TypeDTO
+     */
+    TypeDTO getType(List<String> path);
+
+    /**
+     * This method returns the {@link org.phoenicis.repository.dto.CategoryDTO}, which can be found at the given
+     * path.
+     *
+     * @param path The path, where the searched CategoryDTO can be found
+     * @return The found CategoryDTO
+     */
+    CategoryDTO getCategory(List<String> path);
 
     /**
      * This method returns the {@link org.phoenicis.repository.dto.ApplicationDTO}, which can be found at the given


### PR DESCRIPTION
fixes #1626
requires https://github.com/PhoenicisOrg/scripts/pull/1159

We cannot use the default category buttons (of the apps) in the library tab for several reasons:
- It cannot be guaranteed that the repository which contained the category of a certain app does still exist after the app has been installed (e.g. the repository might have been deleted).
 - It should not be required to fetch the repository to use the library.

Therefore, use the following approach:
- When installing an app, store the icon for its category together with the shortcut (i.e. in the library).
- Use this icon as fallback if the theme does not specify an icon for this category.

#### Why I store the category icon for every shortcut
It is necessary to store the category icon per shortcut, otherwise category icons in the library could be overwritten if multiple shortcuts from different sources use the same category. This could lead to a strange behavior in the following case:

1. an app A with category C and category icon I(A) from repository R1 is installed
2. if the theme does not specify an icon, I(A) is shown in the library
3. an app B with category C and category icon I(B) from repository R2 is installed such that I(A) != I(B) (even though the category C is the same)
4. if the theme does not specify an icon, I(B) is shown in the library
5. app B is uninstalled
6. if the theme does not specify an icon, I(B) is still shown in the library even though the situation is the same as in 2.