### PR TITLE
Load repository only if required

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -19,6 +19,7 @@
 package org.phoenicis.javafx.controller;
 
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
 import org.phoenicis.javafx.components.common.skin.SidebarToggleGroupBaseSkin;
 import org.phoenicis.javafx.components.installation.control.InstallationsFeaturePanel;
 import org.phoenicis.javafx.controller.apps.AppsController;
@@ -93,16 +94,13 @@ public class MainController {
         // tabs:
         // - apps (apps are stored in the repository)
         // - containers (engine settings etc.)
-        this.mainWindow.getApplicationsTab().selectedProperty().addListener((observable, oldValue, newValue) -> {
+        final ChangeListener<Boolean> tabSelectedListener = (observable, oldValue, newValue) -> {
             if (newValue && !repositoryManager.isRepositoryLoaded()) {
                 repositoryManager.triggerRepositoryChange();
             }
-        });
-        this.mainWindow.getContainersTab().selectedProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue && !repositoryManager.isRepositoryLoaded()) {
-                repositoryManager.triggerRepositoryChange();
-            }
-        });
+        };
+        this.mainWindow.getApplicationsTab().selectedProperty().addListener(tabSelectedListener);
+        this.mainWindow.getContainersTab().selectedProperty().addListener(tabSelectedListener);
     }
 
     public void show() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -85,6 +85,14 @@ public class MainController {
 
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);
 
+        // load repository only if it is really required, i.e.
+        // - if one of the following tabs is opened
+        // and
+        // - if the repository has not been loaded already (avoid reload by opening the tab several times)
+        //
+        // tabs:
+        // - apps (apps are stored in the repository)
+        // - containers (engine settings etc.)
         this.mainWindow.getApplicationsTab().selectedProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue && !repositoryManager.isRepositoryLoaded()) {
                 repositoryManager.triggerRepositoryChange();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/MainController.java
@@ -80,12 +80,21 @@ public class MainController {
         this.themeManager = themeManager;
         this.javaFxSettingsManager = javaFxSettingsManager;
 
-        // set callbacks and ensure that they are really called at least once initially
         repositoryManager.addCallbacks(this::setDefaultCategoryIcons, e -> {
         });
-        repositoryManager.triggerCallbacks();
 
         installationsView.setOnInstallationAdded(this.mainWindow::showInstallations);
+
+        this.mainWindow.getApplicationsTab().selectedProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue && !repositoryManager.isRepositoryLoaded()) {
+                repositoryManager.triggerRepositoryChange();
+            }
+        });
+        this.mainWindow.getContainersTab().selectedProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue && !repositoryManager.isRepositoryLoaded()) {
+                repositoryManager.triggerRepositoryChange();
+            }
+        });
     }
 
     public void show() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -89,8 +89,6 @@ public class ContainersController {
 
                     errorDialog.showAndWait();
                 }));
-
-        repositoryManager.triggerCallbacks();
     }
 
     public ContainersFeaturePanel getView() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/library/LibraryController.java
@@ -41,9 +41,7 @@ public class LibraryController {
         this.libraryManager = libraryManager;
 
         this.libraryManager.setOnUpdate(this::populate);
-
-        repositoryManager.addCallbacks(repository -> this.populate(), this::showError);
-        repositoryManager.triggerCallbacks();
+        this.libraryManager.refresh();
     }
 
     private void populate() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/MainWindow.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/MainWindow.java
@@ -49,6 +49,12 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
 
 public class MainWindow extends Stage {
     private TabPane tabPane;
+    private Tab libraryTab;
+    private Tab applicationsTab;
+    private Tab containersTab;
+    private Tab enginesTab;
+    private Tab installationsTab;
+    private Tab settingsTab;
 
     public MainWindow(String applicationName,
             LibraryFeaturePanel library,
@@ -61,14 +67,25 @@ public class MainWindow extends Stage {
             JavaFxSettingsManager javaFxSettingsManager) {
         super();
 
-        tabPane = new TabPane();
-        tabPane.setId("menuPane");
-        tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+        this.tabPane = new TabPane();
+        this.tabPane.setId("menuPane");
+        this.tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
 
-        tabPane.getTabs().addAll(createLibraryTab(library), createApplicationsTab(apps),
-                createContainersTab(containers), engines, createInstallationsTab(installations), settings);
+        this.libraryTab = createLibraryTab(library);
+        this.applicationsTab = createApplicationsTab(apps);
+        this.containersTab = createContainersTab(containers);
+        this.enginesTab = engines;
+        this.installationsTab = createInstallationsTab(installations);
+        this.settingsTab = settings;
+        this.tabPane.getTabs().addAll(
+                this.libraryTab,
+                this.applicationsTab,
+                this.containersTab,
+                this.enginesTab,
+                this.installationsTab,
+                this.settingsTab);
 
-        final Scene scene = new PhoenicisScene(tabPane, themeManager, javaFxSettingsManager);
+        final Scene scene = new PhoenicisScene(this.tabPane, themeManager, javaFxSettingsManager);
 
         this.getIcons().add(new Image(
                 JavaFXApplication.class.getResourceAsStream("/org/phoenicis/javafx/views/common/phoenicis.png")));
@@ -154,6 +171,30 @@ public class MainWindow extends Stage {
     }
 
     public void showInstallations() {
-        tabPane.getSelectionModel().select(4);
+        this.tabPane.getSelectionModel().select(4);
+    }
+
+    public Tab getLibraryTab() {
+        return this.libraryTab;
+    }
+
+    public Tab getApplicationsTab() {
+        return this.applicationsTab;
+    }
+
+    public Tab getContainersTab() {
+        return this.containersTab;
+    }
+
+    public Tab getEnginesTab() {
+        return this.enginesTab;
+    }
+
+    public Tab getInstallationsTab() {
+        return this.installationsTab;
+    }
+
+    public Tab getSettingsTab() {
+        return this.settingsTab;
     }
 }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
@@ -162,7 +162,6 @@ public class DefaultRepositoryManager implements RepositoryManager {
     @Override
     public synchronized void triggerRepositoryChange() {
         this.cachedRepository.clearCache();
-        this.isRepositoryLoaded = true;
         triggerCallbacks();
     }
 
@@ -172,6 +171,7 @@ public class DefaultRepositoryManager implements RepositoryManager {
             this.backgroundRepository.fetchInstallableApplications(repositoryDTO -> {
                 this.callbacks.forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(tr(repositoryDTO)));
             }, exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
+            this.isRepositoryLoaded = true;
         }
     }
 

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
@@ -171,6 +171,9 @@ public class DefaultRepositoryManager implements RepositoryManager {
             this.backgroundRepository.fetchInstallableApplications(repositoryDTO -> {
                 this.callbacks.forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(tr(repositoryDTO)));
             }, exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
+            // do not set this in triggerRepositoryChange()
+            // if no callbacks are registered, fetchInstallableApplications is not called and the repository is not
+            // loaded
             this.isRepositoryLoaded = true;
         }
     }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/DefaultRepositoryManager.java
@@ -39,6 +39,8 @@ public class DefaultRepositoryManager implements RepositoryManager {
 
     private List<CallbackPair> callbacks;
 
+    private boolean isRepositoryLoaded = false;
+
     public DefaultRepositoryManager(ExecutorService executorService, String cacheDirectoryPath,
             LocalRepository.Factory localRepositoryFactory, ClasspathRepository.Factory classPathRepositoryFactory,
             BackgroundRepository.Factory backgroundRepositoryFactory) {
@@ -160,6 +162,7 @@ public class DefaultRepositoryManager implements RepositoryManager {
     @Override
     public synchronized void triggerRepositoryChange() {
         this.cachedRepository.clearCache();
+        this.isRepositoryLoaded = true;
         triggerCallbacks();
     }
 
@@ -170,6 +173,11 @@ public class DefaultRepositoryManager implements RepositoryManager {
                 this.callbacks.forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(tr(repositoryDTO)));
             }, exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
         }
+    }
+
+    @Override
+    public synchronized boolean isRepositoryLoaded() {
+        return isRepositoryLoaded;
     }
 
     private class CallbackPair {

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryManager.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryManager.java
@@ -108,4 +108,10 @@ public interface RepositoryManager {
      * In contrast to {@link #triggerRepositoryChange()}, it does not update the repository before.
      */
     void triggerCallbacks();
+
+    /**
+     * This method checks if the repository has been loaded at least once.
+     * @return true if repository has been loaded
+     */
+    boolean isRepositoryLoaded();
 }


### PR DESCRIPTION
fixes #2037

load repository only if it is really required, i.e.
- if one of the following tabs is opened
and
- if the repository has not been loaded already (avoid reload by opening the tab several times)

tabs:
- apps (apps are stored in the repository)
- containers (engine settings etc.)