### PR TITLE
Update build page, using JDK 13

### DIFF
--- a/docs/_docs/Developers/build.md
+++ b/docs/_docs/Developers/build.md
@@ -10,16 +10,8 @@ toc: true
 * Install the dependencies:
 ```
 sudo apt update
-sudo apt install git maven openjdk-11-jdk fakeroot
+sudo apt install git maven openjdk-13-jdk fakeroot
 ```
-
-* Optional: if your distribution does not support Java 11+ **or** if you need to create packages, grab the latest JDK 
-```
- wget https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz -O /tmp/openjdk-11+28_linux-x64_bin.tar.gz
- sudo tar xfvz /tmp/openjdk-11+28_linux-x64_bin.tar.gz --directory /usr/lib/jvm
- export JAVA_HOME="/usr/lib/jvm/jdk-11"
-```
- 
 
 * Clone the repository from GitHub:
 ```
@@ -28,7 +20,7 @@ git clone https://github.com/PhoenicisOrg/phoenicis.git
 
 * Set the Java version:
 ```
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-13-openjdk-amd64
 ```
 
 * Build Phoenicis:


### PR DESCRIPTION
Solves the https://github.com/PhoenicisOrg/phoenicis/issues/2115 so .deb package is working.
As for the optional step, I was unable to find a working link so I've removed it for now.
