### PR TITLE
Downloader: close URL connection after download

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
@@ -231,18 +231,15 @@ public class LibraryFeaturePanel extends FeaturePanel<LibraryFeaturePanel, Libra
                 .withMessage(tr("Are you sure you want to uninstall {0}?", shortcutName))
                 .withOwner(getScene().getWindow())
                 .withResizable(true)
-                .withYesCallback(() -> {
-                    getShortcutManager().uninstallFromShortcut(shortcut, e -> {
-                        final ErrorDialog errorDialog = ErrorDialog.builder()
-                                .withMessage(tr("Error while uninstalling {0}", shortcutName))
-                                .withException(e)
-                                .withOwner(getScene().getWindow())
-                                .build();
+                .withYesCallback(() -> getShortcutManager().uninstallFromShortcut(shortcut, e -> {
+                    final ErrorDialog errorDialog = ErrorDialog.builder()
+                            .withMessage(tr("Error while uninstalling {0}", shortcutName))
+                            .withException(e)
+                            .withOwner(getScene().getWindow())
+                            .build();
 
-                        errorDialog.showAndWait();
-                    });
-                    // TODO: how can the feature panel close itself?
-                })
+                    errorDialog.showAndWait();
+                }))
                 .build();
 
         confirmMessage.showAndCallback();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/library/control/LibraryFeaturePanel.java
@@ -231,15 +231,18 @@ public class LibraryFeaturePanel extends FeaturePanel<LibraryFeaturePanel, Libra
                 .withMessage(tr("Are you sure you want to uninstall {0}?", shortcutName))
                 .withOwner(getScene().getWindow())
                 .withResizable(true)
-                .withYesCallback(() -> getShortcutManager().uninstallFromShortcut(shortcut, e -> {
-                    final ErrorDialog errorDialog = ErrorDialog.builder()
-                            .withMessage(tr("Error while uninstalling {0}", shortcutName))
-                            .withException(e)
-                            .withOwner(getScene().getWindow())
-                            .build();
+                .withYesCallback(() -> {
+                    getShortcutManager().uninstallFromShortcut(shortcut, e -> {
+                        final ErrorDialog errorDialog = ErrorDialog.builder()
+                                .withMessage(tr("Error while uninstalling {0}", shortcutName))
+                                .withException(e)
+                                .withOwner(getScene().getWindow())
+                                .build();
 
-                    errorDialog.showAndWait();
-                }))
+                        errorDialog.showAndWait();
+                    });
+                    // TODO: how can the feature panel close itself?
+                })
                 .build();
 
         confirmMessage.showAndCallback();

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/http/Downloader.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/http/Downloader.java
@@ -159,6 +159,8 @@ public class Downloader {
                     localFile)) {
                 saveConnectionToStream(url, connection, fileOutputStream, onChange);
                 return new File(directory, fileName);
+            } finally {
+                connection.disconnect();
             }
         } catch (IOException e) {
             throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, url), e);
@@ -258,6 +260,7 @@ public class Downloader {
 
             connection.connect();
             saveConnectionToStream(url, connection, outputStream, onChange);
+            connection.disconnect();
         } catch (IOException e) {
             throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, url), e);
         }
@@ -362,11 +365,12 @@ public class Downloader {
             connection.connect();
             long fileLastModified = localFile.lastModified();
             long urlLastModified = connection.getLastModified();
+            connection.disconnect();
             if (fileLastModified == 0 || urlLastModified == 0) {
                 // we know nothing
                 return true;
             }
-            return localFile.lastModified() <= connection.getLastModified();
+            return fileLastModified <= urlLastModified;
         } catch (IOException e) {
             throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, url), e);
         }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/http/PhoenicisUrlConnection.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/http/PhoenicisUrlConnection.java
@@ -11,7 +11,7 @@ import java.util.Map;
  */
 class PhoenicisUrlConnection {
     private Integer responseCode;
-    private HttpURLConnection delegateUrlConnexion;
+    private HttpURLConnection delegateUrlConnection;
     private URL url;
     private Map<String, String> headers;
 
@@ -23,7 +23,7 @@ class PhoenicisUrlConnection {
      * @see #fromURL(URL) to build
      */
     private PhoenicisUrlConnection(HttpURLConnection urlConnection, URL url) {
-        this.delegateUrlConnexion = urlConnection;
+        this.delegateUrlConnection = urlConnection;
         this.url = url;
         this.responseCode = null;
     }
@@ -54,12 +54,19 @@ class PhoenicisUrlConnection {
     }
 
     /**
+     * Disconnect the connection
+     */
+    void disconnect() {
+        this.delegateUrlConnection.disconnect();
+    }
+
+    /**
      * Get last modified header
      *
      * @return last modified
      */
     long getLastModified() {
-        return delegateUrlConnexion.getLastModified();
+        return delegateUrlConnection.getLastModified();
     }
 
     /**
@@ -69,7 +76,7 @@ class PhoenicisUrlConnection {
      * @throws IOException if any IO error happens
      */
     InputStream getInputStream() throws IOException {
-        return delegateUrlConnexion.getInputStream();
+        return delegateUrlConnection.getInputStream();
     }
 
     /**
@@ -78,7 +85,7 @@ class PhoenicisUrlConnection {
      * @return the content-length of the resource
      */
     long getContentLengthLong() {
-        return delegateUrlConnexion.getContentLengthLong();
+        return delegateUrlConnection.getContentLengthLong();
     }
 
     /**
@@ -93,7 +100,7 @@ class PhoenicisUrlConnection {
         int responseCode = this.getReponseCode();
 
         if (responseCode == 200) {
-            final String disposition = delegateUrlConnexion.getHeaderField("Content-Disposition");
+            final String disposition = delegateUrlConnection.getHeaderField("Content-Disposition");
             if (disposition != null) {
                 int index = disposition.indexOf("filename=");
                 if (index > 0) {
@@ -129,14 +136,14 @@ class PhoenicisUrlConnection {
      */
     private int followRedirectsAndGetResponseCode() throws IOException {
         if (responseCode == null) {
-            responseCode = delegateUrlConnexion.getResponseCode();
+            responseCode = delegateUrlConnection.getResponseCode();
         }
 
         if (responseCode == 302 || responseCode == 301) {
-            final String redirectLocation = delegateUrlConnexion.getHeaderField("Location");
+            final String redirectLocation = delegateUrlConnection.getHeaderField("Location");
             this.url = new URL(redirectLocation);
-            this.delegateUrlConnexion = (HttpURLConnection) url.openConnection();
-            this.delegateUrlConnexion.setInstanceFollowRedirects(false);
+            this.delegateUrlConnection = (HttpURLConnection) url.openConnection();
+            this.delegateUrlConnection.setInstanceFollowRedirects(false);
             this.responseCode = null;
             if (this.headers != null) {
                 setHeaders(headers);
@@ -153,6 +160,6 @@ class PhoenicisUrlConnection {
      */
     void setHeaders(Map<String, String> headers) {
         this.headers = headers;
-        headers.forEach(delegateUrlConnexion::setRequestProperty);
+        headers.forEach(delegateUrlConnection::setRequestProperty);
     }
 }


### PR DESCRIPTION
fixes #1807

The problem was that two connections for the Wine versions json are opened. The first to check if an update is available (`Downloader#isUpdateAvailable()`), the second to actually download the file (`Downloader#get()`). If e.g. `Downloader#isUpdateAvailable()` does not open a connection but returns `true` immediately, the download in `Downloader#get()` starts directly.

I'm not completely sure what happens in the background but my assumption is that the underlying socket is closed by the `disconnect` such that the next connection can setup a new socket immediately.