### PR TITLE
Fix flatpak

### DIFF
--- a/docs/_docs/Developers/packages.md
+++ b/docs/_docs/Developers/packages.md
@@ -15,7 +15,14 @@ The built packages are located in the target/packages folder:
 Required extensions:
 - org.freedesktop.Platform.Compat.i386
 - org.freedesktop.Platform.GL32.nvidia-415-25
+- org.freedesktop.Sdk.Extension.openjdk11
 
+**NOTE:** Newer versions of the OpenJDK extension cause issues with Graal.
+Downgrade to the OpenJDK 11.0.6 version with:
+```
+sudo flatpak update --commit c554d684bdfc4ab5f09a99b554c3c9b219770416e4af257c2715b2810df2b850 org.freedesktop.Sdk.Extension.openjdk11//19.08
+```
+build with:
 ```
 cd phoenicis-dist/src/flatpak/
 flatpak-builder build-dir org.phoenicis.playonlinux.yml --force-clean --user --install

--- a/phoenicis-dist/src/flatpak/distribution.xml
+++ b/phoenicis-dist/src/flatpak/distribution.xml
@@ -36,42 +36,12 @@
             </includes>
 			<outputDirectory></outputDirectory>
         </fileSet>
-        <!-- graal dependencies -->
         <fileSet>
             <directory>${project.build.directory}/lib</directory>
             <includes>
-                <include>compiler.jar</include>
-                <include>truffle-api.jar</include>
-                <include>graal-sdk.jar</include>
+                <include>*.jar</include>
             </includes>
 			<outputDirectory>lib</outputDirectory>
         </fileSet>
     </fileSets>
-	<dependencySets>
-		<dependencySet>
-			<outputDirectory>lib</outputDirectory>
-			<unpack>false</unpack>
-            <excludes>
-                <exclude>org.graalvm.compiler:compiler</exclude>
-                <exclude>org.graalvm.truffle:truffle-api</exclude>
-                <exclude>org.graalvm.sdk:graal-sdk</exclude>
-            </excludes>
-		</dependencySet>
-	</dependencySets>
-	<moduleSets>
-		<moduleSet>
-			<!-- Enable access to all projects in the current multimodule build! -->
-			<useAllReactorProjects>true</useAllReactorProjects>
-
-			<!-- Now, select which projects to include in this module-set. -->
-			<includes>
-				<include>org.phoenicis:phoenicis-javafx</include>
-			</includes>
-			<binaries>
-				<outputDirectory>lib</outputDirectory>
-				<unpack>false</unpack>
-				<includeDependencies>false</includeDependencies>
-			</binaries>
-		</moduleSet>
-	</moduleSets>
 </assembly>

--- a/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
+++ b/phoenicis-dist/src/flatpak/org.phoenicis.playonlinux.yml
@@ -71,4 +71,4 @@ modules:
         dest-filename: phoenicis-playonlinux
         commands:
           # do not use Wine runtime (e.g. Notepad++ crashes otherwise)
-          - /app/jre/bin/java -Dapplication.environment.wineRuntime=false --module-path /app/phoenicis/lib/ --add-modules=jdk.crypto.ec,java.base,javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls,java.naming,java.sql,java.scripting,jdk.internal.vm.ci,jdk.internal.vm.compiler,org.graalvm.truffle,jdk.jsobject,jdk.xml.dom -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -cp "/app/phoenicis/lib/*" --upgrade-module-path=/app/phoenicis/lib/compiler.jar org.phoenicis.javafx.JavaFXApplication "$@"
+          - /app/jre/bin/java -Dapplication.environment.wineRuntime=false --add-modules=jdk.crypto.ec,java.base,javafx.base,javafx.web,javafx.media,javafx.graphics,javafx.controls,java.naming,java.sql,java.scripting,jdk.internal.vm.ci,jdk.internal.vm.compiler,org.graalvm.truffle,jdk.jsobject,jdk.xml.dom --module-path /app/phoenicis/lib/ -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -cp "/app/phoenicis/lib/*" --upgrade-module-path=/app/phoenicis/lib/compiler.jar org.phoenicis.javafx.JavaFXApplication "$@"


### PR DESCRIPTION
Install only .jar's in `phoenicis-dist/target/lib` to avoid issues with split packages etc.