### PR TITLE
add fakeroot to dockerfile = successful building on gitpod.io

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,10 +1,17 @@
 FROM gitpod/workspace-full-vnc:latest
 
-RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get -y install cabextract libxext6 libxext6:i386 libfreetype6 libfreetype6:i386
-
+USER root
+RUN dpkg --add-architecture i386 \
+  && apt-get update \
+  && apt-get install -y \
+    cabextract \
+    libxext6 \
+    libxext6:i386 \
+    libfreetype6 \
+    libfreetype6:i386 \
+    fakeroot \
+&& apt-get clean && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 
 USER gitpod
-
 # activate java 11. It's already installed in the base image.
 RUN  bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,5 +11,5 @@ tasks:
 - init: >
     mvn install
   command: >
-    cd phoenicis-javafx/ &&
-    mvn exec:java
+    cd phoenicis-dist/src/scripts &&
+    sh phoenicis-create-package.sh


### PR DESCRIPTION
I couldn't get this to compile on gitpod because it was lacking fakeroot.  Also, the original does something in the subfolder javafx. The build guide [here](https://phoenicisorg.github.io/phoenicis/Developers/build/#ubuntu-18041810-and-linux-mint-19) says to run a bash script in the phoenicis-dist/src/scripts folder, so I changed the yml file too. It now produces a very installable .deb file.

Instead of _USER root_, it's also possible to run _sudo_ in the dockerfile.  Not sure if it really matters at this point in time.
[reference](https://www.gitpod.io/docs/config-docker/) -- here they say not to use _USER root_, but then they link you to [this example](https://www.gitpod.io/blog/docker-in-gitpod/), which uses _USER root_... so...?

Last but not least, as of [this post](https://github.com/gitpod-io/gitpod/issues/39#issuecomment-738636446) you can now enable sudo in new workspaces by enabling 'Feature Preview' in settings, but that's rather round-about to fix a missing package.