### PR TITLE
Fix "engine" written twice

### DIFF
--- a/i18n/keys.pot
+++ b/i18n/keys.pot
@@ -300,7 +300,7 @@ msgid "Are you sure you want to delete the {0} container?"
 msgstr ""
 
 #: phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersFeaturePanel.java:180
-msgid "Error during engine engine version change"
+msgid "Error during engine version change"
 msgstr ""
 
 #: phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersFeaturePanel.java:205

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersFeaturePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/components/container/control/ContainersFeaturePanel.java
@@ -177,7 +177,7 @@ public class ContainersFeaturePanel extends FeaturePanel<ContainersFeaturePanel,
                     engine -> engine.changeVersion(container.getName()),
                     exception -> Platform.runLater(() -> {
                         final ErrorDialog errorDialog = ErrorDialog.builder()
-                                .withMessage(tr("Error during engine engine version change"))
+                                .withMessage(tr("Error during engine version change"))
                                 .withException(exception)
                                 .withOwner(getScene().getWindow())
                                 .build();


### PR DESCRIPTION
In string [#2334](https://crowdin.com/translate/phoenicis/3/en#2334)
––––––––––
Off-topic: Hebrew is 100% now. May you review the translations and add them to the official release, please?