### PR TITLE
Revert GraalVM to 21.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <mockito.version>4.0.0</mockito.version>
         <spring.version>5.3.10</spring.version>
         <formatter-maven-plugin.version>2.16.0</formatter-maven-plugin.version>
-        <graalvm.version>21.2.0</graalvm.version>
+        <graalvm.version>21.0.0</graalvm.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
avoid `TypeError: (intermediate value).from is not a function` in https://github.com/PhoenicisOrg/scripts/blob/6bccb916f7d0942b68f34ade128e4248336844ab/Engines/Wine/Engine/Versions/script.js#L26