### PR TITLE
Fix: dependabot PRs auto merged even if CI failed

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -18,3 +18,4 @@ jobs:
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE }}
+          ENABLE_GITHUB_API_PREVIEW: true


### PR DESCRIPTION
see:
- https://github.com/ridedott/merge-me-action/issues/863
- https://github.com/ridedott/merge-me-action#opting-in-for-using-github-preview-apis