### PR TITLE
merge-me action: check only CI

### DIFF
--- a/.github/workflows/merge-me.yml
+++ b/.github/workflows/merge-me.yml
@@ -6,7 +6,6 @@ on:
       - completed
     workflows:
       - 'CI'
-      - 'Lint .java files'
 
 jobs:
   merge-me:


### PR DESCRIPTION
As described in https://github.com/ridedott/merge-me-action/issues/1212, the action runs as soon as **any** workflow in `workflows` completed. This means that it usually ran after linting the Java files and thus ignored if the CI failed.

Ignoring the linting workflow is not optimal. However, the current behavior is way worse. Also, merge-me is meant for dependabot PRs which should not produce linting issues in general.