### PR TITLE
Revert "Bump spring.version from 5.3.23 to 6.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <logback.version>1.4.4</logback.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>4.9.0</mockito.version>
-        <spring.version>6.0.0</spring.version>
+        <spring.version>5.3.23</spring.version>
         <formatter-maven-plugin.version>2.21.0</formatter-maven-plugin.version>
         <graalvm.version>21.1.0</graalvm.version>
         <buildnumber.version>3.0.0</buildnumber.version>


### PR DESCRIPTION
Reverts PhoenicisOrg/phoenicis#2598

build fails with `class file has wrong version 61.0, should be 55.0`