### PR TITLE
CI: update EndBug/add-and-commit to v9

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,7 +20,7 @@ jobs:
         run: mvn formatter:format
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v6
+        uses: EndBug/add-and-commit@v9
         with:
           author_name: PhoenicisBot
           author_email: git@phoenicis.org


### PR DESCRIPTION
fixes:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: EndBug/add-and-commit@v6. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```