### PR TITLE
CI: update actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cd phoenicis-dist/src/scripts
           bash phoenicis-create-package.sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Ubuntu
           path: phoenicis-dist/target/*.deb
@@ -94,7 +94,7 @@ jobs:
         run: |
           cd phoenicis-dist/src/scripts
           bash phoenicis-create-package.sh
-      #- uses: actions/upload-artifact@v2
+      #- uses: actions/upload-artifact@v3
       #  with:
       #    name: Mac OS
       #    path: phoenicis-dist/target/packages/*.app


### PR DESCRIPTION
fixes:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```