### PR TITLE
CI: use ubuntu-latest for Flatpak build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: mvn clean package
   flatpak:
     name: Flatpak
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11


### PR DESCRIPTION
The build failed with:
```
Err:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libavahi-glib1 amd64 0.7-4ubuntu7.1
  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/a/avahi/libavahi-glib1_0.7-4ubuntu7.1_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```